### PR TITLE
BUG-FIX: added kwargs to plugins 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         "--extend-ignore=E203,W503"
     ]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
+  rev: v0.812
   hooks:
   - id: mypy
     args: [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         "--extend-ignore=E203,W503"
     ]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.812
+  rev: v0.991
   hooks:
   - id: mypy
     args: [

--- a/src/synthcity/plugins/generic/plugin_marginal_distributions.py
+++ b/src/synthcity/plugins/generic/plugin_marginal_distributions.py
@@ -35,7 +35,7 @@ class MarginalDistributionPlugin(Plugin):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(
-            sampling_strategy="marginal",
+            sampling_strategy="marginal", **kwargs
         )
 
     @staticmethod

--- a/src/synthcity/plugins/generic/plugin_marginal_distributions.py
+++ b/src/synthcity/plugins/generic/plugin_marginal_distributions.py
@@ -34,9 +34,7 @@ class MarginalDistributionPlugin(Plugin):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(
-            sampling_strategy="marginal", **kwargs
-        )
+        super().__init__(sampling_strategy="marginal", **kwargs)
 
     @staticmethod
     def name() -> str:

--- a/src/synthcity/plugins/generic/plugin_uniform_sampler.py
+++ b/src/synthcity/plugins/generic/plugin_uniform_sampler.py
@@ -34,7 +34,7 @@ class UniformSamplerPlugin(Plugin):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(sampling_strategy="uniform")
+        super().__init__(sampling_strategy="uniform", **kwargs)
 
     @staticmethod
     def name() -> str:

--- a/tests/plugins/time_series/test_ts_marginal_distributions.py
+++ b/tests/plugins/time_series/test_ts_marginal_distributions.py
@@ -91,9 +91,7 @@ def test_plugin_generate_survival() -> None:
         time_horizons=time_horizons,
     )
 
-    test_plugin = plugin(
-        n_iter=10,
-    )
+    test_plugin = plugin()
     test_plugin.fit(survival_data)
 
     X_gen = test_plugin.generate(10)


### PR DESCRIPTION
A small fix of passing *kwargs* to the `uniform_sampler` and `marginal_distirbutions` plugins that can be useful (at least to me). After changing the src code, I re-installed the package and successfully ran the relevant tests. 