### PR TITLE
[WIP] Added AlphaPrecisionNaive

### DIFF
--- a/src/synthcity/benchmark/__init__.py
+++ b/src/synthcity/benchmark/__init__.py
@@ -169,7 +169,6 @@ class Benchmarks:
 
                     if synthetic_cache:
                         save_to_file(cache_file, X_syn)
-
                 evaluation = Metrics.evaluate(
                     X_test if X_test is not None else X,
                     X_syn,

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -42,6 +42,7 @@ from .eval_sanity import (
 )
 from .eval_statistical import (
     AlphaPrecision,
+    AlphaPrecisionNaive,
     ChiSquaredTest,
     FrechetInceptionDistance,
     InverseKLDivergence,
@@ -70,6 +71,7 @@ standard_metrics = [
     WassersteinDistance,
     PRDCScore,
     AlphaPrecision,
+    AlphaPrecisionNaive,
     SurvivalKMDistance,
     FrechetInceptionDistance,
     # performance tests
@@ -170,7 +172,6 @@ class Metrics:
         scores = ScoreEvaluator()
 
         eval_cnt = min(len(X_gt), len(X_syn))
-
         for metric in standard_metrics:
             if metric.type() not in metrics:
                 continue

--- a/src/synthcity/metrics/eval_statistical.py
+++ b/src/synthcity/metrics/eval_statistical.py
@@ -574,7 +574,7 @@ class AlphaPrecision(StatisticalEvaluator):
         emb_center: Optional[np.ndarray] = None,
     ) -> Tuple:
         if len(X) != len(X_syn):
-            raise RuntimeError("The real and synthetic data mush have the same length")
+            raise RuntimeError("The real and synthetic data must have the same length")
 
         if emb_center is None:
             emb_center = np.mean(X.numpy(), axis=0)
@@ -684,6 +684,158 @@ class AlphaPrecision(StatisticalEvaluator):
         results[f"authenticity{emb}"] = authenticity
 
         return results
+
+
+class AlphaPrecisionNaive(StatisticalEvaluator):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def name() -> str:
+        return "alpha_precision_naive"
+
+    @staticmethod
+    def direction() -> str:
+        return "maximize"
+
+    def metrics(
+        self,
+        X_df: pd.DataFrame,
+        X_syn_df: pd.DataFrame,
+    ) -> Tuple:
+        X = X_df.values.astype(float)
+        X_syn = X_syn_df.values.astype(float)
+        assert len(X) == len(
+            X_syn
+        ), "The real and synthetic data mush have the same length"
+
+        emb_center = np.mean(X, axis=0)
+
+        n_steps = 30
+        alphas = np.linspace(0, 1, n_steps)
+
+        Radii = np.quantile(np.sqrt(np.sum((X - emb_center) ** 2, axis=1)), alphas)
+
+        synth_center = np.mean(X_syn, axis=0)
+
+        alpha_precision_curve = []
+        beta_coverage_curve = []
+
+        synth_to_center = np.sqrt(np.sum((X_syn - emb_center) ** 2, axis=1))
+
+        nbrs_real = NearestNeighbors(n_neighbors=2, n_jobs=-1, p=2).fit(X)
+        real_to_real, _ = nbrs_real.kneighbors(X)
+
+        nbrs_synth = NearestNeighbors(n_neighbors=1, n_jobs=-1, p=2).fit(X_syn)
+        real_to_synth, real_to_synth_args = nbrs_synth.kneighbors(X)
+
+        # Let us find closest real point to any real point, excluding itself (therefore 1 instead of 0)
+        real_to_real = real_to_real[:, 1].squeeze()
+        real_to_synth = real_to_synth.squeeze()
+        real_to_synth_args = real_to_synth_args.squeeze()
+
+        real_synth_closest = X_syn[real_to_synth_args]
+
+        real_synth_closest_d = np.sqrt(
+            np.sum((real_synth_closest - synth_center) ** 2, axis=1)
+        )
+        closest_synth_Radii = np.quantile(real_synth_closest_d, alphas)
+
+        for k in range(len(Radii)):
+            precision_audit_mask = synth_to_center <= Radii[k]
+            alpha_precision = np.mean(precision_audit_mask)
+
+            beta_coverage = np.mean(
+                (
+                    (real_to_synth <= real_to_real)
+                    * (real_synth_closest_d <= closest_synth_Radii[k])
+                )
+            )
+
+            alpha_precision_curve.append(alpha_precision)
+            beta_coverage_curve.append(beta_coverage)
+
+        # See which one is bigger
+
+        authen = real_to_real[real_to_synth_args] < real_to_synth
+        authenticity = np.mean(authen)
+
+        Delta_precision_alpha = 1 - np.sum(
+            np.abs(np.array(alphas) - np.array(alpha_precision_curve))
+        ) / np.sum(alphas)
+
+        if Delta_precision_alpha < 0:
+            raise RuntimeError("negative value detected for Delta_precision_alpha")
+
+        Delta_coverage_beta = 1 - np.sum(
+            np.abs(np.array(alphas) - np.array(beta_coverage_curve))
+        ) / np.sum(alphas)
+
+        if Delta_coverage_beta < 0:
+            raise RuntimeError("negative value detected for Delta_coverage_beta")
+
+        return (
+            alphas,
+            alpha_precision_curve,
+            beta_coverage_curve,
+            Delta_precision_alpha,
+            Delta_coverage_beta,
+            authenticity,
+        )
+
+    def _normalize_covariates(
+        self,
+        X: DataLoader,
+        X_syn: DataLoader,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        X_gt_norm = X.dataframe().copy()
+        X_syn_norm = X_syn.dataframe().copy()
+        if self._task_type != "survival_analysis":
+            X_gt_norm = X_gt_norm.drop(columns=[X.target_column])
+            X_syn_norm = X_syn_norm.drop(columns=[X_syn.target_column])
+        scaler = MinMaxScaler().fit(X_gt_norm)
+        return (
+            pd.DataFrame(
+                scaler.transform(X_gt_norm),
+                columns=[
+                    col
+                    for col in X.train().dataframe().columns
+                    if col != X.target_column
+                ],
+            ),
+            pd.DataFrame(
+                scaler.transform(X_syn_norm),
+                columns=[
+                    col
+                    for col in X_syn.dataframe().columns
+                    if col != X_syn.target_column
+                ],
+            ),
+        )
+
+    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    def _evaluate(
+        self,
+        X: DataLoader,
+        X_syn: DataLoader,
+    ) -> Dict:
+
+        X_df, X_syn_df = self._normalize_covariates(X, X_syn)
+
+        (
+            alphas,
+            alpha_precision_curve,
+            beta_coverage_curve,
+            Delta_precision_alpha,
+            Delta_coverage_beta,
+            authenticity,
+        ) = self.metrics(X_df, X_syn_df)
+
+        return {
+            "delta_precision_alpha": Delta_precision_alpha,
+            "delta_coverage_beta": Delta_coverage_beta,
+            "authenticity": authenticity,
+        }
 
 
 class SurvivalKMDistance(StatisticalEvaluator):

--- a/src/synthcity/metrics/scores.py
+++ b/src/synthcity/metrics/scores.py
@@ -42,7 +42,7 @@ def _safe_evaluate(
     log.debug(f" >> Evaluating metric {evaluator.fqdn()} done. Duration: {duration} s")
 
     if err is not None:
-        log.error(f" >> Rvaluator {evaluator.fqdn()} failed: {err}")
+        log.error(f" >> Evaluator {evaluator.fqdn()} failed: {err}")
 
     return evaluator.fqdn(), result, failed, duration, evaluator.direction()
 


### PR DESCRIPTION
## Description
Adds the statistical metric AlphaPrecisionNaive, which is used by [this repo] (https://github.com/vanderschaarlab/GOGGLE). For most uses cases AlphaPrecision remains the metric to use.

## Affected Dependencies
None

## How has this been tested?
- [ ] Added `test_evaluate_alpha_precision_naive` to tests/test_statistical.py

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
