### PR TITLE
Fix bugs, including `PBCDataloader` incorrect preprocessing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     numpy>=1.20
     lifelines>=0.27
     opacus>=1.3
-    decaf-synthetic-data>=0.1.5
+    decaf-synthetic-data>=0.1.6
     optuna>=3.1
     shap
     tqdm

--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -675,7 +675,7 @@ class PerformanceEvaluatorXGB(PerformanceEvaluator):
                     "n_jobs": 2,
                     "verbosity": 0,
                     "depth": 3,
-                    "strategy": "weibull",  # "weibull", "debiased_bce"
+                    "strategy": "debiased_bce",  # "weibull", "debiased_bce"
                     "random_state": self._random_state,
                 },
                 X_gt,
@@ -705,7 +705,7 @@ class PerformanceEvaluatorXGB(PerformanceEvaluator):
                     "n_jobs": 2,
                     "verbosity": 0,
                     "depth": 3,
-                    "strategy": "weibull",  # "weibull", "debiased_bce"
+                    "strategy": "debiased_bce",  # "weibull", "debiased_bce"
                     "random_state": self._random_state,
                 },
                 X_gt,
@@ -1033,7 +1033,7 @@ class FeatureImportanceRankDistance(MetricEvaluator):
                 n_jobs=2,
                 verbosity=0,
                 depth=3,
-                strategy="weibull",  # "weibull", "debiased_bce"
+                strategy="debiased_bce",  # "weibull", "debiased_bce"
                 random_state=self._random_state,
             )
 

--- a/src/synthcity/plugins/core/models/ts_model.py
+++ b/src/synthcity/plugins/core/models/ts_model.py
@@ -704,6 +704,7 @@ class WindowLinearLayer(nn.Module):
 
         self.device = device
         self.window_size = window_size
+        self.n_static_units_in = n_static_units_in
         self.model = MLP(
             task_type="regression",
             n_units_in=n_static_units_in + n_temporal_units_in * window_size,
@@ -719,7 +720,7 @@ class WindowLinearLayer(nn.Module):
     def forward(
         self, static_data: torch.Tensor, temporal_data: torch.Tensor
     ) -> torch.Tensor:
-        if len(static_data) != len(temporal_data):
+        if self.n_static_units_in > 0 and len(static_data) != len(temporal_data):
             raise ValueError("Length mismatch between static and temporal data")
 
         batch_size, seq_len, n_feats = temporal_data.shape

--- a/src/synthcity/utils/datasets/time_series/pbc.py
+++ b/src/synthcity/utils/datasets/time_series/pbc.py
@@ -62,7 +62,7 @@ class PBCDataloader:
             data = pd.read_csv(df_path)
 
         data["time"] = data["years"] - data["year"]
-        data = data.sort_values(by="time")
+        data = data.sort_values(by=["id", "time"], ignore_index=True)
         data["histologic"] = data["histologic"].astype(str)
         dat_cat = data[
             ["drug", "sex", "ascites", "hepatomegaly", "spiders", "edema", "histologic"]
@@ -136,6 +136,14 @@ class PBCDataloader:
             patient = x_[data["id"] == id_]
 
             patient_static = patient[static_cols]
+            if (
+                not (patient_static.iloc[0] == patient_static).all().all()
+            ):  # pragma: no cover
+                # This is a sanity check.
+                raise RuntimeError(
+                    "Found patient with static data that are not actually fixed:\n"
+                    f"id: {id_}\n{patient_static}"
+                )
             x_static.append(patient_static.values[0].tolist())
 
             patient_temporal = patient[temporal_cols]


### PR DESCRIPTION
## Description
Fix three bugs:
1. 1e3d6b438d4d705a8b108f4cbef3e5aa7db823b6 fixes the "did not converge" error in tests involving `XGBSurvivalAnalysis`/`XGBTimeSeriesSurvival`. The tests that would previously (at least in some cases) fail include [`tests/metrics/test_performance.py::test_evaluate_performance_survival_analysis[PerformanceEvaluatorXGB-test_plugin0]`](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/tests/metrics/test_performance.py#L222). The fix was to change the `strategy` from `"weibull"` to the more stable `"debiased_bce"`.
1. f309351250ebbb8b026ef767d7f92ec00d39ad53 fixes the failing check in [`WindowLinearLayer.forward`](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/src/synthcity/plugins/core/models/ts_model.py#L723), which would fail when a length zero tensor was provided (i.e. no static data case). The conditional only needs to run if static data is expected, so an extra check added to fix this. The tests that would previously (at least in some cases) fail include: [`tests/plugins/core/models/test_ts_tabular_vae.py::test_ts_vae_generation[GoogleStocksDataloader]`](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/tests/plugins/core/models/test_ts_tabular_vae.py#L55).
1. 1e3d6b438d4d705a8b108f4cbef3e5aa7db823b6 fixes incorrect preprocessing in [`PBCDataloader`](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/src/synthcity/utils/datasets/time_series/pbc.py#L17).
   - Steps to replicate:
       - If you add [this sanity check](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/src/synthcity/utils/datasets/time_series/pbc.py#L139), which checks that the static features extracted from the source data are indeed unchanging (over time steps) for each patient...
       - ...You find that this fails in the original implementation (run `from synthcity.utils.datasets.time_series.pbc import PBCDataloader; PBCDataloader(as_numpy=True).load()`).
    - Why is this happening? The dataframes used in preprocessing steps mix up the indexes of the samples at the [sorting step](https://github.com/vanderschaarlab/synthcity/blob/f309351250ebbb8b026ef767d7f92ec00d39ad53/src/synthcity/utils/datasets/time_series/pbc.py#L65), and at [a later step](https://github.com/vanderschaarlab/synthcity/blob/f309351250ebbb8b026ef767d7f92ec00d39ad53/src/synthcity/utils/datasets/time_series/pbc.py#L136) attempt to reference the old indexes - which leads to mixing up different patients' data together. This is now [fixed](https://github.com/vanderschaarlab/synthcity/blob/DrShushen/fix-PBCDataloader-preprocessing/src/synthcity/utils/datasets/time_series/pbc.py#L65) by resetting the index at the sorting step.

## Affected Dependencies
None.

## How has this been tested?
- No new tests are required.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
