### PR TITLE
feat: pass batch size to predict in dynamic deephit

### DIFF
--- a/src/synthcity/plugins/core/models/time_series_survival/ts_surv_dynamic_deephit.py
+++ b/src/synthcity/plugins/core/models/time_series_survival/ts_surv_dynamic_deephit.py
@@ -141,6 +141,7 @@ class DynamicDeephitTimeSeriesSurvival(TimeSeriesSurvivalPlugin):
         temporal: Union[np.ndarray, List],
         observation_times: Union[np.ndarray, List],
         time_horizons: List,
+        batch_size: Optional[int] = 100,
     ) -> np.ndarray:
         "Predict risk"
         static = np.asarray(static)
@@ -150,7 +151,8 @@ class DynamicDeephitTimeSeriesSurvival(TimeSeriesSurvivalPlugin):
         data = self._merge_data(static, temporal, observation_times)
 
         return pd.DataFrame(
-            self.model.predict_risk(data, time_horizons), columns=time_horizons
+            self.model.predict_risk(data, time_horizons, bs=batch_size),
+            columns=time_horizons,
         )
 
     @validate_arguments(config=dict(arbitrary_types_allowed=True))
@@ -221,7 +223,6 @@ class DynamicDeepHitModel:
         clipping_value: int = 1,
         output_type: str = "MLP",
     ) -> None:
-
         self.split = split
         self.split_time = None
 


### PR DESCRIPTION
## Description
This PR adds the option to supply a `batch_size` argument to the `predict` method of dynamic deephit that will be passed down to  `predict_survival`. This can drastically speed up evaluation.
 
## Affected Dependencies
NA

## How has this been tested?
pytest

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A) Don't have the rights to do this
- [x] My changes are covered by tests
