### PR TITLE
Skipif goggle tests

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r prereq.txt
-
             pip install --upgrade pip
       - name: Test Core
         run: |

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -30,6 +30,11 @@ jobs:
             pip install -r prereq.txt
 
             pip install --upgrade pip
-            pip install .[all]
-      - name: Test with pytest
-        run: pytest -vvvs --durations=50
+      - name: Test Core
+        run: |
+          pip install .[testing]
+          pytest -vvvs --durations=50
+      - name: Test GOGGLE
+        run: |
+          pip install .[testing,goggle]
+          pytest -vvvs -k goggle --durations=50

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -57,6 +57,6 @@ jobs:
             pip install -r prereq.txt
 
             pip install --upgrade pip
-            pip install .[all]
+            pip install .[testing]
       - name: Test with pytest
         run: pytest -vvvs -m "not slow" --durations=50

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -55,8 +55,12 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r prereq.txt
-
             pip install --upgrade pip
-            pip install .[all]
-      - name: Test with pytest
-        run: pytest -vvvs -m "not slow" --durations=50
+      - name: Test Core
+        run: |
+          pip install .[testing]
+          pytest -vvvs -m "not slow" --durations=50
+      - name: Test GOGGLE
+        run: |
+          pip install .[testing,goggle]
+          pytest -vvvs -k goggle

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -57,6 +57,6 @@ jobs:
             pip install -r prereq.txt
 
             pip install --upgrade pip
-            pip install .[testing]
+            pip install .[all]
       - name: Test with pytest
         run: pytest -vvvs -m "not slow" --durations=50

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -1,4 +1,4 @@
-name: Tests Python
+name: Tests Fast Python
 
 on:
   push:

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Test GOGGLE
         run: |
           pip install .[testing,goggle]
-          pytest -vvvs -k goggle
+          pytest -vvvs -m "not slow" -k goggle

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Test Core
         run: |
           pip install .[testing]
-          pytest -vvvs -m "not slow" --durations=50
+          pytest -vvvsx -m "not slow" --durations=50
       - name: Test GOGGLE
         run: |
           pip install .[testing,goggle]
-          pytest -vvvs -m "not slow" -k goggle
+          pytest -vvvsx -m "not slow" -k goggle

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -35,7 +35,7 @@ jobs:
             pip install -r prereq.txt
             pip install --upgrade pip
 
-            pip install .[all]
+            pip install .[testing]
 
             python -m pip install ipykernel
             python -m ipykernel install --user

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -35,7 +35,7 @@ jobs:
             pip install -r prereq.txt
             pip install --upgrade pip
 
-            pip install .[testing]
+            pip install .[all]
 
             python -m pip install ipykernel
             python -m ipykernel install --user

--- a/prereq.txt
+++ b/prereq.txt
@@ -1,3 +1,3 @@
 numpy
-torch<2.0.0
+torch
 tsai

--- a/prereq.txt
+++ b/prereq.txt
@@ -1,3 +1,3 @@
 numpy
-torch
+torch<2.0
 tsai

--- a/prereq.txt
+++ b/prereq.txt
@@ -1,3 +1,3 @@
 numpy
-torch
+torch<2.0.0
 tsai

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     scikit-learn>=1.0
     nflows>=0.14
     pandas>=1.3,<2.0
-    torch>=1.10
+    torch>=1.10,<2.0
     numpy>=1.20
     lifelines>=0.27
     opacus>=1.3
@@ -92,7 +92,6 @@ testing =
     click
 
 goggle =
-    torch<2.0
     dgl
     torch_geometric
     torch_sparse

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     scikit-learn>=1.0
     nflows>=0.14
     pandas>=1.3
-    torch>=1.10.0
+    torch<2.0.0
     numpy>=1.20
     lifelines>=0.27
     opacus>=1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ python_requires = >=3.7
 install_requires =
     scikit-learn>=1.0
     nflows>=0.14
-    pandas>=1.3
-    torch<2.0.0
+    pandas>=1.3,<2.0
+    torch>=1.10
     numpy>=1.20
     lifelines>=0.27
     opacus>=1.3
@@ -92,6 +92,7 @@ testing =
     click
 
 goggle =
+    torch<2.0
     dgl
     torch_geometric
     torch_sparse

--- a/src/synthcity/plugins/generic/plugin_goggle.py
+++ b/src/synthcity/plugins/generic/plugin_goggle.py
@@ -23,10 +23,17 @@ from synthcity.plugins.core.distribution import (
     FloatDistribution,
     IntegerDistribution,
 )
-from synthcity.plugins.core.models.tabular_goggle import TabularGoggle
 from synthcity.plugins.core.plugin import Plugin
 from synthcity.plugins.core.schema import Schema
 from synthcity.utils.constants import DEVICE
+
+try:
+    # synthcity absolute
+    from synthcity.plugins.core.models.tabular_goggle import TabularGoggle
+
+    module_disabled = False
+except ImportError:
+    module_disabled = True
 
 
 class GOGGLEPlugin(Plugin):
@@ -248,4 +255,7 @@ class GOGGLEPlugin(Plugin):
         return self._safe_generate(self.model.generate, count, syn_schema)
 
 
-plugin = GOGGLEPlugin
+if module_disabled:
+    plugin = None
+else:
+    plugin = GOGGLEPlugin

--- a/tests/plugins/generic/generic_helpers.py
+++ b/tests/plugins/generic/generic_helpers.py
@@ -10,7 +10,9 @@ from synthcity.plugins.generic import GenericPlugins as Plugins
 from synthcity.utils.serialization import load, save
 
 
-def generate_fixtures(name: str, plugin: Type, plugin_args: Dict = {}) -> List:
+def generate_fixtures(
+    name: str, plugin: Type, plugin_args: Dict = {}, use_dummy_fixtures: bool = False
+) -> List:
     def from_api() -> Plugin:
         return Plugins().get(name, **plugin_args)
 
@@ -21,7 +23,10 @@ def generate_fixtures(name: str, plugin: Type, plugin_args: Dict = {}) -> List:
         buff = save(plugin(**plugin_args))
         return load(buff)
 
-    return [from_api(), from_module(), from_serde()]
+    if use_dummy_fixtures:
+        return [None, None, None]
+    else:
+        return [from_api(), from_module(), from_serde()]
 
 
 def get_airfoil_dataset() -> pd.DataFrame:

--- a/tests/plugins/generic/generic_helpers.py
+++ b/tests/plugins/generic/generic_helpers.py
@@ -1,5 +1,5 @@
 # stdlib
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 # third party
 import pandas as pd
@@ -11,22 +11,22 @@ from synthcity.utils.serialization import load, save
 
 
 def generate_fixtures(
-    name: str, plugin: Type, plugin_args: Dict = {}, use_dummy_fixtures: bool = False
+    name: str, plugin: Optional[Type], plugin_args: Dict = {}
 ) -> List:
+    if plugin is None:
+        return []
+
     def from_api() -> Plugin:
         return Plugins().get(name, **plugin_args)
 
     def from_module() -> Plugin:
-        return plugin(**plugin_args)
+        return plugin(**plugin_args)  # type: ignore
 
     def from_serde() -> Plugin:
-        buff = save(plugin(**plugin_args))
+        buff = save(plugin(**plugin_args))  # type: ignore
         return load(buff)
 
-    if use_dummy_fixtures:
-        return [None, None, None]
-    else:
-        return [from_api(), from_module(), from_serde()]
+    return [from_api(), from_module(), from_serde()]
 
 
 def get_airfoil_dataset() -> pd.DataFrame:

--- a/tests/plugins/generic/test_goggle.py
+++ b/tests/plugins/generic/test_goggle.py
@@ -1,4 +1,3 @@
-# Standard library imports
 # third party
 import numpy as np
 import pkg_resources
@@ -18,7 +17,14 @@ try:
     # synthcity absolute
     from synthcity.plugins.generic.plugin_goggle import plugin
 except ImportError:
-    plugin = None
+    """
+    Import dummy_sampler, but don't use it.
+    A valid plugin is required for generate_fixtures, but all tests should be skipped, if
+    the goggle dependencies are missing.
+    """
+    # synthcity absolute
+    from synthcity.plugins.generic.plugin_dummy_sampler import plugin
+
     is_missing_goggle_deps = True
 
 plugin_name = "goggle"

--- a/tests/plugins/generic/test_goggle.py
+++ b/tests/plugins/generic/test_goggle.py
@@ -137,6 +137,7 @@ def test_plugin_generate_constraints_goggle(test_plugin: Plugin) -> None:
 
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 def test_sample_hyperparams() -> None:
+    assert plugin is not None
     for i in range(100):
         args = plugin.sample_hyperparameters()
         assert plugin(**args) is not None
@@ -162,6 +163,7 @@ def test_eval_performance_goggle(compress_dataset: bool, decoder_arch: str) -> N
     Xraw["target"] = y
     X = GenericDataLoader(Xraw)
 
+    assert plugin is not None
     for retry in range(2):
         test_plugin = plugin(
             n_iter=5000,

--- a/tests/plugins/generic/test_goggle.py
+++ b/tests/plugins/generic/test_goggle.py
@@ -10,22 +10,10 @@ from synthcity.metrics.eval import PerformanceEvaluatorXGB
 from synthcity.plugins import Plugin
 from synthcity.plugins.core.constraints import Constraints
 from synthcity.plugins.core.dataloader import GenericDataLoader
+from synthcity.plugins.generic.plugin_goggle import plugin
 from synthcity.utils.serialization import load, save
 
-is_missing_goggle_deps = False
-try:
-    # synthcity absolute
-    from synthcity.plugins.generic.plugin_goggle import plugin
-except ImportError:
-    """
-    Import dummy_sampler, but don't use it.
-    A valid plugin is required for generate_fixtures, but all tests should be skipped, if
-    the goggle dependencies are missing.
-    """
-    # synthcity absolute
-    from synthcity.plugins.generic.plugin_dummy_sampler import plugin
-
-    is_missing_goggle_deps = True
+is_missing_goggle_deps = plugin is None
 
 plugin_name = "goggle"
 plugin_args = {
@@ -38,13 +26,11 @@ if not is_missing_goggle_deps:
     installed = {pkg.key for pkg in pkg_resources.working_set}
     is_missing_goggle_deps = len(goggle_dependencies - installed) > 0
 
-print(is_missing_goggle_deps)
-
 
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+    generate_fixtures(plugin_name, plugin),
 )
 def test_plugin_sanity(test_plugin: Plugin) -> None:
     assert test_plugin is not None
@@ -53,7 +39,7 @@ def test_plugin_sanity(test_plugin: Plugin) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+    generate_fixtures(plugin_name, plugin),
 )
 def test_plugin_name(test_plugin: Plugin) -> None:
     assert test_plugin.name() == plugin_name
@@ -62,7 +48,7 @@ def test_plugin_name(test_plugin: Plugin) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+    generate_fixtures(plugin_name, plugin),
 )
 def test_plugin_type(test_plugin: Plugin) -> None:
     assert test_plugin.type() == "generic"
@@ -71,7 +57,7 @@ def test_plugin_type(test_plugin: Plugin) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+    generate_fixtures(plugin_name, plugin),
 )
 def test_plugin_hyperparams(test_plugin: Plugin) -> None:
     assert len(test_plugin.hyperparameter_space()) == 9
@@ -80,9 +66,7 @@ def test_plugin_hyperparams(test_plugin: Plugin) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(
-        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
-    ),
+    generate_fixtures(plugin_name, plugin, plugin_args),
 )
 def test_plugin_fit(test_plugin: Plugin) -> None:
     Xraw, y = load_diabetes(return_X_y=True, as_frame=True)
@@ -93,9 +77,7 @@ def test_plugin_fit(test_plugin: Plugin) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(
-        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
-    ),
+    generate_fixtures(plugin_name, plugin, plugin_args),
 )
 @pytest.mark.parametrize("serialize", [True, False])
 def test_plugin_generate(test_plugin: Plugin, serialize: bool) -> None:
@@ -127,9 +109,7 @@ def test_plugin_generate(test_plugin: Plugin, serialize: bool) -> None:
 @pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
     "test_plugin",
-    generate_fixtures(
-        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
-    ),
+    generate_fixtures(plugin_name, plugin, plugin_args),
 )
 def test_plugin_generate_constraints_goggle(test_plugin: Plugin) -> None:
     X, y = load_iris(as_frame=True, return_X_y=True)

--- a/tests/plugins/generic/test_goggle.py
+++ b/tests/plugins/generic/test_goggle.py
@@ -1,5 +1,7 @@
+# Standard library imports
 # third party
 import numpy as np
+import pkg_resources
 import pytest
 from generic_helpers import generate_fixtures
 from sklearn.datasets import load_diabetes, load_iris
@@ -9,8 +11,15 @@ from synthcity.metrics.eval import PerformanceEvaluatorXGB
 from synthcity.plugins import Plugin
 from synthcity.plugins.core.constraints import Constraints
 from synthcity.plugins.core.dataloader import GenericDataLoader
-from synthcity.plugins.generic.plugin_goggle import plugin
 from synthcity.utils.serialization import load, save
+
+is_missing_goggle_deps = False
+try:
+    # synthcity absolute
+    from synthcity.plugins.generic.plugin_goggle import plugin
+except ImportError:
+    plugin = None
+    is_missing_goggle_deps = True
 
 plugin_name = "goggle"
 plugin_args = {
@@ -18,29 +27,56 @@ plugin_args = {
     "device": "cpu",
 }
 
+if not is_missing_goggle_deps:
+    goggle_dependencies = {"dgl", "torch-scatter", "torch-sparse", "torch-geometric"}
+    installed = {pkg.key for pkg in pkg_resources.working_set}
+    is_missing_goggle_deps = len(goggle_dependencies - installed) > 0
 
-@pytest.mark.parametrize("test_plugin", generate_fixtures(plugin_name, plugin))
+print(is_missing_goggle_deps)
+
+
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
+@pytest.mark.parametrize(
+    "test_plugin",
+    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+)
 def test_plugin_sanity(test_plugin: Plugin) -> None:
     assert test_plugin is not None
 
 
-@pytest.mark.parametrize("test_plugin", generate_fixtures(plugin_name, plugin))
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
+@pytest.mark.parametrize(
+    "test_plugin",
+    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+)
 def test_plugin_name(test_plugin: Plugin) -> None:
     assert test_plugin.name() == plugin_name
 
 
-@pytest.mark.parametrize("test_plugin", generate_fixtures(plugin_name, plugin))
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
+@pytest.mark.parametrize(
+    "test_plugin",
+    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+)
 def test_plugin_type(test_plugin: Plugin) -> None:
     assert test_plugin.type() == "generic"
 
 
-@pytest.mark.parametrize("test_plugin", generate_fixtures(plugin_name, plugin))
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
+@pytest.mark.parametrize(
+    "test_plugin",
+    generate_fixtures(plugin_name, plugin, use_dummy_fixtures=is_missing_goggle_deps),
+)
 def test_plugin_hyperparams(test_plugin: Plugin) -> None:
     assert len(test_plugin.hyperparameter_space()) == 9
 
 
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
-    "test_plugin", generate_fixtures(plugin_name, plugin, plugin_args)
+    "test_plugin",
+    generate_fixtures(
+        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
+    ),
 )
 def test_plugin_fit(test_plugin: Plugin) -> None:
     Xraw, y = load_diabetes(return_X_y=True, as_frame=True)
@@ -48,8 +84,12 @@ def test_plugin_fit(test_plugin: Plugin) -> None:
     test_plugin.fit(GenericDataLoader(Xraw))
 
 
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
-    "test_plugin", generate_fixtures(plugin_name, plugin, plugin_args)
+    "test_plugin",
+    generate_fixtures(
+        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
+    ),
 )
 @pytest.mark.parametrize("serialize", [True, False])
 def test_plugin_generate(test_plugin: Plugin, serialize: bool) -> None:
@@ -78,8 +118,12 @@ def test_plugin_generate(test_plugin: Plugin, serialize: bool) -> None:
     assert (X_gen1.numpy() != X_gen3.numpy()).any()
 
 
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.parametrize(
-    "test_plugin", generate_fixtures(plugin_name, plugin, plugin_args)
+    "test_plugin",
+    generate_fixtures(
+        plugin_name, plugin, plugin_args, use_dummy_fixtures=is_missing_goggle_deps
+    ),
 )
 def test_plugin_generate_constraints_goggle(test_plugin: Plugin) -> None:
     X, y = load_iris(as_frame=True, return_X_y=True)
@@ -105,12 +149,14 @@ def test_plugin_generate_constraints_goggle(test_plugin: Plugin) -> None:
     assert list(X_gen.columns) == list(X.columns)
 
 
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 def test_sample_hyperparams() -> None:
     for i in range(100):
         args = plugin.sample_hyperparameters()
         assert plugin(**args) is not None
 
 
+@pytest.mark.skipif(is_missing_goggle_deps, reason="Goggle dependencies not installed")
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "compress_dataset,decoder_arch",


### PR DESCRIPTION
## Description
Skip goggle tests if dependencies not installed. Closes #169 

**Also:**
Fixing failing tests for GAN:
- pin torch<2.0
- pin pandas<2.0
- update workflows to install `.[testing]` not `.[all]`
- Test CORE and GOGGLE separately.
- handle plugins that cannot be loaded(with missing deps)


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
