### PR TITLE
Bugfix: test_evaluate_performance_survival_analysis-test

### DIFF
--- a/tests/metrics/test_performance.py
+++ b/tests/metrics/test_performance.py
@@ -254,7 +254,11 @@ def test_evaluate_performance_survival_analysis(
     assert "syn_ood.brier_score" in good_score
 
     sz = 100
-    X_rnd = pd.DataFrame(np.random.randn(sz, len(X.columns)), columns=X.columns)
+    X_rnd = pd.DataFrame(
+        np.random.randn(sz, len(X.columns) - 1),
+        columns=[col for col in X.columns if col != "week"],
+    )
+    X_rnd.insert(loc=0, column="week", value=np.random.randint(1, 52, size=sz))
     X_rnd["arrest"] = 1
     score = evaluator.evaluate(
         Xloader,


### PR DESCRIPTION
## Description
Bugfix for failing test marked slow, "test_evaluate_performance_survival_analysis-test". This bug was introduced as the test was not compatible with #147. closes #173 

## How has this been tested?
- The test now passes

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
