### PR TITLE
158 no support for columns of type uint

### DIFF
--- a/src/synthcity/plugins/core/schema.py
+++ b/src/synthcity/plugins/core/schema.py
@@ -73,7 +73,7 @@ class Schema(BaseModel):
                     feature_domain[col] = CategoricalDistribution(
                         name=col, data=X[col], random_state=random_state
                     )
-                elif X[col].dtype.kind == "i":
+                elif X[col].dtype.kind in ["i", "u"]:
                     feature_domain[col] = IntegerDistribution(
                         name=col, data=X[col], random_state=random_state
                     )
@@ -95,7 +95,7 @@ class Schema(BaseModel):
                         choices=list(X[col].unique()),
                         random_state=random_state,
                     )
-                elif X[col].dtype.kind == "i":
+                elif X[col].dtype.kind in ["i", "u"]:
                     feature_domain[col] = IntegerDistribution(
                         name=col,
                         low=X[col].min(),

--- a/tests/plugins/core/test_schema.py
+++ b/tests/plugins/core/test_schema.py
@@ -1,4 +1,5 @@
 # third party
+import numpy as np
 import pandas as pd
 import pydantic
 import pytest
@@ -14,7 +15,24 @@ def test_schema_fail() -> None:
 
 
 def test_schema_ok() -> None:
-    data = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+    data = pd.DataFrame(
+        {
+            "a": pd.Series(["a", "b", "c"], dtype="object"),
+            "b": pd.Series([True, False, True], dtype="boolean"),
+            "c": pd.Series([1, 2, 3], dtype="int8"),
+            "d": pd.Series([4.0, 5.0, 6.0], dtype="float32"),
+            "e": pd.Series([7, 8, 9], dtype="uint8"),
+            "f": pd.Series(["odd", "even", "odd"], dtype="category"),
+            "g": pd.Series(
+                [
+                    np.datetime64("2023-01-01"),
+                    np.datetime64("2023-01-02"),
+                    np.datetime64("2023-01-03"),
+                ],
+                dtype="datetime64[ns]",
+            ),
+        }
+    )
     schema = Schema(data=data)
 
     assert schema.get("a").name == "a"
@@ -23,12 +41,29 @@ def test_schema_ok() -> None:
 
 
 def test_schema_as_constraint() -> None:
-    data = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+    data = pd.DataFrame(
+        {
+            "a": pd.Series(["a", "b", "c"], dtype="object"),
+            "b": pd.Series([True, False, True], dtype="boolean"),
+            "c": pd.Series([1, 2, 3], dtype="int8"),
+            "d": pd.Series([4.0, 5.0, 6.0], dtype="float32"),
+            "e": pd.Series([7, 8, 9], dtype="uint8"),
+            "f": pd.Series(["odd", "even", "odd"], dtype="category"),
+            "g": pd.Series(
+                [
+                    np.datetime64("2023-01-01"),
+                    np.datetime64("2023-01-02"),
+                    np.datetime64("2023-01-03"),
+                ],
+                dtype="datetime64[ns]",
+            ),
+        }
+    )
     schema = Schema(data=data)
 
     cons = schema.as_constraints()
 
-    assert len(cons) == 3
+    assert len(cons) == 7
     for rule in cons:
         assert rule[1] == "in"
 


### PR DESCRIPTION
## Description
Support for columns of type `uint`. Closes #158 

## Affected Dependencies
None

## How has this been tested?
- Added different dtypes to `test_schema.py` including `uint`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
