### PR TITLE
fix: ddpm fails if run on GPU

### DIFF
--- a/src/synthcity/plugins/core/models/tabular_ddpm/gaussian_multinomial_diffsuion.py
+++ b/src/synthcity/plugins/core/models/tabular_ddpm/gaussian_multinomial_diffsuion.py
@@ -157,7 +157,7 @@ class GaussianMultinomialDiffusion(torch.nn.Module):
         self.posterior_log_variance_clipped = (
             torch.from_numpy(
                 np.log(
-                    np.append(self.posterior_variance[1], self.posterior_variance[1:])
+                    np.append(self.posterior_variance[1].cpu(), self.posterior_variance[1:].cpu())
                 )
             )
             .float()


### PR DESCRIPTION
## Description
ddpm currently fails if run on a CUDA GPU device, as the cuda tensors cannot be cast to numpy without being moved to the CPU first. This small PR fixes it. 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [ ] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
