### PR TITLE
[WIP] 189 test failing in tutorials

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pandas>=1.3,<2.0
     torch>=1.10.0,<2.0
     numpy>=1.20
-    lifelines>=0.27
+    lifelines>=0.27,!= 0.27.5
     opacus>=1.3
     decaf-synthetic-data>=0.1.6
     optuna>=3.1

--- a/src/synthcity/plugins/core/models/layers.py
+++ b/src/synthcity/plugins/core/models/layers.py
@@ -48,8 +48,10 @@ class Transpose(nn.Module):
 def _forward_skip_connection(
     self: nn.Module, X: torch.Tensor, *args: Any, **kwargs: Any
 ) -> torch.Tensor:
-    # if X.shape[-1] == 0:
-    #     return torch.zeros((*X.shape[:-1], self.n_units_out)).to(self.device)
+    if X.shape[-1] == 0:
+        return torch.zeros((*X.shape[:-1], self._modules["model"][0].out_features)).to(
+            self.device
+        )
     X = X.float().to(self.device)
     out = self._forward(X, *args, **kwargs)
     return torch.cat([out, X], dim=-1)
@@ -74,23 +76,6 @@ def SkipConnection(cls: Type[nn.Module]) -> Type[nn.Module]:
     Wrapper.__qualname__ = f"SkipConnection({cls.__qualname__})"
     Wrapper.__doc__ = f"""(With skipped connection) {cls.__doc__}"""
     return Wrapper
-
-
-# class GLU(nn.Module):
-#     """Gated Linear Unit (GLU)."""
-
-#     def __init__(self, activation: Union[str, nn.Module] = "sigmoid") -> None:
-#         super().__init__()
-#         if type(activation) == str:
-#             self.non_lin = get_nonlin(activation)
-#         else:
-#             self.non_lin = activation
-
-#     def forward(self, x: Tensor) -> Tensor:
-#         if x.shape[-1] % 2:
-#             raise ValueError("The last dimension of the input tensor must be even.")
-#         a, b = x.chunk(2, dim=-1)
-#         return a * self.non_lin(b)
 
 
 class GumbelSoftmax(nn.Module):

--- a/src/synthcity/plugins/core/models/ts_tabular_gan.py
+++ b/src/synthcity/plugins/core/models/ts_tabular_gan.py
@@ -163,7 +163,7 @@ class TimeSeriesTabularGAN(torch.nn.Module):
         self.static_columns = static_data.columns
         self.temporal_columns = temporal_data[0].columns
         n_units_conditional = 0 if cond is None else cond.shape[-1]
-
+        print("n_features:", self.encoder.n_features())
         n_static_units, n_temporal_units = self.encoder.n_features()
         static_act, temporal_act = self.encoder.activation_layout(
             discrete_activation=generator_nonlin_out_discrete,

--- a/src/synthcity/plugins/core/models/ts_tabular_gan.py
+++ b/src/synthcity/plugins/core/models/ts_tabular_gan.py
@@ -163,7 +163,6 @@ class TimeSeriesTabularGAN(torch.nn.Module):
         self.static_columns = static_data.columns
         self.temporal_columns = temporal_data[0].columns
         n_units_conditional = 0 if cond is None else cond.shape[-1]
-        print("n_features:", self.encoder.n_features())
         n_static_units, n_temporal_units = self.encoder.n_features()
         static_act, temporal_act = self.encoder.activation_layout(
             discrete_activation=generator_nonlin_out_discrete,

--- a/src/synthcity/plugins/core/models/ts_tabular_gan.py
+++ b/src/synthcity/plugins/core/models/ts_tabular_gan.py
@@ -163,6 +163,7 @@ class TimeSeriesTabularGAN(torch.nn.Module):
         self.static_columns = static_data.columns
         self.temporal_columns = temporal_data[0].columns
         n_units_conditional = 0 if cond is None else cond.shape[-1]
+
         n_static_units, n_temporal_units = self.encoder.n_features()
         static_act, temporal_act = self.encoder.activation_layout(
             discrete_activation=generator_nonlin_out_discrete,


### PR DESCRIPTION
## Description
The timegan tutorial test was failing due to the lack of static data in the googlestocks data. This fix adds in the ability to handle this case. closes #189 

## Affected Dependencies
Additionally this fix adds lifelines!=0.27.5 to requirements, due to a bug in the lifelines release release.

## How has this been tested?
- standard automated test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
