### PR TITLE
197 add tutorial for using hyperimpute + synthcity

### DIFF
--- a/tutorials/tutorial9_dealing_with_missing_data.ipynb
+++ b/tutorials/tutorial9_dealing_with_missing_data.ipynb
@@ -15,6 +15,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Before we start you will need to install the library hyperimpute. This can be done with the command `pip install hyperimpute`."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Imports"
    ]
   },

--- a/tutorials/tutorial9_dealing_with_missing_data.ipynb
+++ b/tutorials/tutorial9_dealing_with_missing_data.ipynb
@@ -1,0 +1,789 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 9: Dealing with missing data\n",
+    "\n",
+    "Synthcity does not handle missing data on it's own. It assumes that you have imputed any missing values yourself first. So, in this tutorial, we will learn how to do this with another of the van der Schaar Lab's modules, `HyperImpute`. We will then show that we can happily generate a synthetic data afterwards."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import warnings\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import load_diabetes\n",
+    "\n",
+    "from hyperimpute.plugins.utils.simulate import simulate_nan\n",
+    "\n",
+    "from IPython.display import display\n",
+    "\n",
+    "if not sys.warnoptions:\n",
+    "    warnings.simplefilter(\"ignore\")\n",
+    "\n",
+    "from synthcity.plugins.core.dataloader import GenericDataLoader"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the data\n",
+    "\n",
+    "We will use the diabetes dataset from SKLearn, but we need to introduce some NaN values in order to simulate the missingness that we will then fix with HyperImpute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The diabetes dataset with 20% missing values.\n",
+      "\n",
+      "        age       sex       bmi        bp        s1        s2        s3  \\\n",
+      "0  0.038076  0.050680  0.061696       NaN       NaN -0.034821 -0.043401   \n",
+      "1 -0.001882 -0.044642 -0.051474 -0.026328 -0.008449 -0.019163  0.074412   \n",
+      "2  0.085299  0.050680  0.044451       NaN -0.045599       NaN -0.032356   \n",
+      "3       NaN -0.044642       NaN -0.036656  0.012191       NaN -0.036038   \n",
+      "4  0.005383       NaN -0.036385  0.021872       NaN       NaN  0.008142   \n",
+      "\n",
+      "         s4        s5        s6  target  \n",
+      "0 -0.002592  0.019907 -0.017646     NaN  \n",
+      "1 -0.039493 -0.068332 -0.092204    75.0  \n",
+      "2 -0.002592  0.002861 -0.025930   141.0  \n",
+      "3  0.034309  0.022688 -0.009362   206.0  \n",
+      "4       NaN -0.031988       NaN     NaN  \n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# Load baseline dataset\n",
+    "X, y = load_diabetes(as_frame=True, return_X_y=True)\n",
+    "df_ = pd.concat([X, y], axis=1)\n",
+    "\n",
+    "# Simulate missing data\n",
+    "percentage_missing = 0.2\n",
+    "mechanism = \"MCAR\"\n",
+    "x_miss = simulate_nan(np.asarray(df_), percentage_missing, mechanism)[\"X_incomp\"]\n",
+    "\n",
+    "\n",
+    "df = pd.DataFrame(x_miss, columns = df_.columns)\n",
+    "print(\"The diabetes dataset with 20% missing values.\\n\")\n",
+    "print(df.head())\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Try to Generate synthetic data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = GenericDataLoader(\n",
+    "    df,\n",
+    "    target_column=\"target\",\n",
+    "    sensitive_columns=[\"sex\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-06-01 17:21:10,321 - Created a temporary directory at /tmp/tmp0xnhplub\n",
+      "2023-06-01 17:21:10,322 - Writing /tmp/tmp0xnhplub/_remote_module_non_scriptable.py\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Input X contains NaN.\nBayesianGaussianMixture does not accept missing values encoded as NaN natively. For supervised learning, you might want to consider sklearn.ensemble.HistGradientBoostingClassifier and Regressor which accept missing values encoded as NaNs natively. Alternatively, it is possible to preprocess the data, for instance by using an imputer transformer in a pipeline or drop samples with missing values. See https://scikit-learn.org/stable/modules/impute.html You can find a list of all estimators that handle NaN values at the following page: https://scikit-learn.org/stable/modules/impute.html#estimators-that-handle-nan-values",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 6\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39msynthcity\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mplugins\u001b[39;00m \u001b[39mimport\u001b[39;00m Plugins\n\u001b[1;32m      4\u001b[0m syn_model \u001b[39m=\u001b[39m Plugins()\u001b[39m.\u001b[39mget(\u001b[39m\"\u001b[39m\u001b[39mctgan\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m----> 6\u001b[0m syn_model\u001b[39m.\u001b[39;49mfit(loader)\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:40\u001b[0m, in \u001b[0;36mpydantic.decorator.validate_arguments.validate.wrapper_function\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:134\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.call\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:206\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.execute\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/plugin.py:244\u001b[0m, in \u001b[0;36mPlugin.fit\u001b[0;34m(self, X, *args, **kwargs)\u001b[0m\n\u001b[1;32m    236\u001b[0m         X, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcompress_context \u001b[39m=\u001b[39m load_from_file(bkp_file)\n\u001b[1;32m    238\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_training_schema \u001b[39m=\u001b[39m Schema(\n\u001b[1;32m    239\u001b[0m     data\u001b[39m=\u001b[39mX,\n\u001b[1;32m    240\u001b[0m     sampling_strategy\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39msampling_strategy,\n\u001b[1;32m    241\u001b[0m     random_state\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mrandom_state,\n\u001b[1;32m    242\u001b[0m )\n\u001b[0;32m--> 244\u001b[0m output \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_fit(X, \u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    245\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfitted \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[1;32m    247\u001b[0m \u001b[39mreturn\u001b[39;00m output\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/generic/plugin_ctgan.py:239\u001b[0m, in \u001b[0;36mCTGANPlugin._fit\u001b[0;34m(self, X, *args, **kwargs)\u001b[0m\n\u001b[1;32m    236\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39m\"\u001b[39m\u001b[39mcond\u001b[39m\u001b[39m\"\u001b[39m \u001b[39min\u001b[39;00m kwargs:\n\u001b[1;32m    237\u001b[0m     cond \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_prepare_cond(kwargs[\u001b[39m\"\u001b[39m\u001b[39mcond\u001b[39m\u001b[39m\"\u001b[39m])\n\u001b[0;32m--> 239\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmodel \u001b[39m=\u001b[39m TabularGAN(\n\u001b[1;32m    240\u001b[0m     X\u001b[39m.\u001b[39;49mdataframe(),\n\u001b[1;32m    241\u001b[0m     cond\u001b[39m=\u001b[39;49mcond,\n\u001b[1;32m    242\u001b[0m     n_units_latent\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgenerator_n_units_hidden,\n\u001b[1;32m    243\u001b[0m     batch_size\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mbatch_size,\n\u001b[1;32m    244\u001b[0m     generator_n_layers_hidden\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgenerator_n_layers_hidden,\n\u001b[1;32m    245\u001b[0m     generator_n_units_hidden\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgenerator_n_units_hidden,\n\u001b[1;32m    246\u001b[0m     generator_nonlin\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgenerator_nonlin,\n\u001b[1;32m    247\u001b[0m     generator_nonlin_out_discrete\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39msoftmax\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m    248\u001b[0m     generator_nonlin_out_continuous\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mnone\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m    249\u001b[0m     generator_lr\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mlr,\n\u001b[1;32m    250\u001b[0m     generator_residual\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    251\u001b[0m     generator_n_iter\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mn_iter,\n\u001b[1;32m    252\u001b[0m     generator_batch_norm\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    253\u001b[0m     generator_dropout\u001b[39m=\u001b[39;49m\u001b[39m0\u001b[39;49m,\n\u001b[1;32m    254\u001b[0m     generator_weight_decay\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mweight_decay,\n\u001b[1;32m    255\u001b[0m     generator_opt_betas\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgenerator_opt_betas,\n\u001b[1;32m    256\u001b[0m     generator_extra_penalties\u001b[39m=\u001b[39;49m[],\n\u001b[1;32m    257\u001b[0m     discriminator_n_units_hidden\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_n_units_hidden,\n\u001b[1;32m    258\u001b[0m     discriminator_n_layers_hidden\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_n_layers_hidden,\n\u001b[1;32m    259\u001b[0m     discriminator_n_iter\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_n_iter,\n\u001b[1;32m    260\u001b[0m     discriminator_nonlin\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_nonlin,\n\u001b[1;32m    261\u001b[0m     discriminator_batch_norm\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    262\u001b[0m     discriminator_dropout\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_dropout,\n\u001b[1;32m    263\u001b[0m     discriminator_lr\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mlr,\n\u001b[1;32m    264\u001b[0m     discriminator_weight_decay\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mweight_decay,\n\u001b[1;32m    265\u001b[0m     discriminator_opt_betas\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdiscriminator_opt_betas,\n\u001b[1;32m    266\u001b[0m     encoder\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mencoder,\n\u001b[1;32m    267\u001b[0m     clipping_value\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mclipping_value,\n\u001b[1;32m    268\u001b[0m     lambda_gradient_penalty\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mlambda_gradient_penalty,\n\u001b[1;32m    269\u001b[0m     encoder_max_clusters\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mencoder_max_clusters,\n\u001b[1;32m    270\u001b[0m     dataloader_sampler\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdataloader_sampler,\n\u001b[1;32m    271\u001b[0m     device\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mdevice,\n\u001b[1;32m    272\u001b[0m     patience\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpatience,\n\u001b[1;32m    273\u001b[0m     patience_metric\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpatience_metric,\n\u001b[1;32m    274\u001b[0m     n_iter_min\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mn_iter_min,\n\u001b[1;32m    275\u001b[0m     n_iter_print\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mn_iter_print,\n\u001b[1;32m    276\u001b[0m     adjust_inference_sampling\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49madjust_inference_sampling,\n\u001b[1;32m    277\u001b[0m )\n\u001b[1;32m    278\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmodel\u001b[39m.\u001b[39mfit(X\u001b[39m.\u001b[39mdataframe(), cond\u001b[39m=\u001b[39mcond)\n\u001b[1;32m    280\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:40\u001b[0m, in \u001b[0;36mpydantic.decorator.validate_arguments.validate.wrapper_function\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:134\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.call\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:206\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.execute\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/models/tabular_gan.py:184\u001b[0m, in \u001b[0;36mTabularGAN.__init__\u001b[0;34m(self, X, n_units_latent, cond, generator_n_layers_hidden, generator_n_units_hidden, generator_nonlin, generator_nonlin_out_discrete, generator_nonlin_out_continuous, generator_n_iter, generator_batch_norm, generator_dropout, generator_lr, generator_weight_decay, generator_opt_betas, generator_residual, generator_extra_penalties, discriminator_n_layers_hidden, discriminator_n_units_hidden, discriminator_nonlin, discriminator_n_iter, discriminator_batch_norm, discriminator_dropout, discriminator_lr, discriminator_weight_decay, discriminator_opt_betas, batch_size, random_state, clipping_value, lambda_gradient_penalty, lambda_identifiability_penalty, encoder_max_clusters, encoder, encoder_whitelist, dataloader_sampler, device, patience, patience_metric, n_iter_print, n_iter_min, adjust_inference_sampling, dp_enabled, dp_epsilon, dp_delta, dp_max_grad_norm, dp_secure_mode)\u001b[0m\n\u001b[1;32m    182\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mencoder \u001b[39m=\u001b[39m encoder\n\u001b[1;32m    183\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 184\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mencoder \u001b[39m=\u001b[39m TabularEncoder(\n\u001b[1;32m    185\u001b[0m         max_clusters\u001b[39m=\u001b[39;49mencoder_max_clusters, whitelist\u001b[39m=\u001b[39;49mencoder_whitelist\n\u001b[1;32m    186\u001b[0m     )\u001b[39m.\u001b[39;49mfit(X)\n\u001b[1;32m    188\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcond_encoder: Optional[OneHotEncoder] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    189\u001b[0m \u001b[39mif\u001b[39;00m cond \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:40\u001b[0m, in \u001b[0;36mpydantic.decorator.validate_arguments.validate.wrapper_function\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:134\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.call\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:206\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.execute\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/models/tabular_encoder.py:158\u001b[0m, in \u001b[0;36mTabularEncoder.fit\u001b[0;34m(self, raw_data, discrete_columns)\u001b[0m\n\u001b[1;32m    156\u001b[0m log\u001b[39m.\u001b[39minfo(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mEncoding \u001b[39m\u001b[39m{\u001b[39;00mname\u001b[39m}\u001b[39;00m\u001b[39m \u001b[39m\u001b[39m{\u001b[39;00mcolumn_hash\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    157\u001b[0m ftype \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mdiscrete\u001b[39m\u001b[39m\"\u001b[39m \u001b[39mif\u001b[39;00m name \u001b[39min\u001b[39;00m discrete_columns \u001b[39melse\u001b[39;00m \u001b[39m\"\u001b[39m\u001b[39mcontinuous\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 158\u001b[0m column_transform_info \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_fit_feature(raw_data[name], ftype)\n\u001b[1;32m    160\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39moutput_dimensions \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m column_transform_info\u001b[39m.\u001b[39moutput_dimensions\n\u001b[1;32m    161\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_column_transform_info_list\u001b[39m.\u001b[39mappend(column_transform_info)\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:40\u001b[0m, in \u001b[0;36mpydantic.decorator.validate_arguments.validate.wrapper_function\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:134\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.call\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:206\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.execute\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/models/tabular_encoder.py:125\u001b[0m, in \u001b[0;36mTabularEncoder._fit_feature\u001b[0;34m(self, feature, feature_type)\u001b[0m\n\u001b[1;32m    120\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    121\u001b[0m     encoder \u001b[39m=\u001b[39m get_feature_encoder(\n\u001b[1;32m    122\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcontinuous_encoder, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcont_encoder_params\n\u001b[1;32m    123\u001b[0m     )\n\u001b[0;32m--> 125\u001b[0m encoder\u001b[39m.\u001b[39;49mfit(feature)\n\u001b[1;32m    127\u001b[0m \u001b[39mreturn\u001b[39;00m FeatureInfo(\n\u001b[1;32m    128\u001b[0m     name\u001b[39m=\u001b[39mfeature\u001b[39m.\u001b[39mname,\n\u001b[1;32m    129\u001b[0m     feature_type\u001b[39m=\u001b[39mfeature_type,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    133\u001b[0m     trans_feature_types\u001b[39m=\u001b[39mencoder\u001b[39m.\u001b[39mfeature_types_out,\n\u001b[1;32m    134\u001b[0m )\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:40\u001b[0m, in \u001b[0;36mpydantic.decorator.validate_arguments.validate.wrapper_function\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:134\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.call\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/pydantic/decorator.py:206\u001b[0m, in \u001b[0;36mpydantic.decorator.ValidatedFunction.execute\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/models/feature_encoder.py:68\u001b[0m, in \u001b[0;36mFeatureEncoder.fit\u001b[0;34m(self, x, y, **kwargs)\u001b[0m\n\u001b[1;32m     66\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfeature_type_in \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_get_feature_type(x)\n\u001b[1;32m     67\u001b[0m \u001b[39minput\u001b[39m \u001b[39m=\u001b[39m validate_shape(x\u001b[39m.\u001b[39mvalues, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mn_dim_in)\n\u001b[0;32m---> 68\u001b[0m output \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_fit(\u001b[39minput\u001b[39;49m, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\u001b[39m.\u001b[39m_transform(\u001b[39minput\u001b[39m)\n\u001b[1;32m     69\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_out_shape \u001b[39m=\u001b[39m (\u001b[39m-\u001b[39m\u001b[39m1\u001b[39m, \u001b[39m*\u001b[39moutput\u001b[39m.\u001b[39mshape[\u001b[39m1\u001b[39m:])  \u001b[39m# for inverse_transform\u001b[39;00m\n\u001b[1;32m     70\u001b[0m output \u001b[39m=\u001b[39m validate_shape(output, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mn_dim_out)\n",
+      "File \u001b[0;32m~/Documents/projects/synthcity/src/synthcity/plugins/core/models/feature_encoder.py:208\u001b[0m, in \u001b[0;36mBayesianGMMEncoder._fit\u001b[0;34m(self, x, **kwargs)\u001b[0m\n\u001b[1;32m    205\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmin_value \u001b[39m=\u001b[39m x\u001b[39m.\u001b[39mmin()\n\u001b[1;32m    206\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmax_value \u001b[39m=\u001b[39m x\u001b[39m.\u001b[39mmax()\n\u001b[0;32m--> 208\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mmodel\u001b[39m.\u001b[39;49mfit(x)\n\u001b[1;32m    209\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mweights \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmodel\u001b[39m.\u001b[39mweights_\n\u001b[1;32m    210\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmeans \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmodel\u001b[39m.\u001b[39mmeans_\u001b[39m.\u001b[39mreshape(\u001b[39m-\u001b[39m\u001b[39m1\u001b[39m)\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/sklearn/mixture/_base.py:186\u001b[0m, in \u001b[0;36mBaseMixture.fit\u001b[0;34m(self, X, y)\u001b[0m\n\u001b[1;32m    160\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Estimate model parameters with the EM algorithm.\u001b[39;00m\n\u001b[1;32m    161\u001b[0m \n\u001b[1;32m    162\u001b[0m \u001b[39mThe method fits the model ``n_init`` times and sets the parameters with\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    183\u001b[0m \u001b[39m    The fitted mixture.\u001b[39;00m\n\u001b[1;32m    184\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    185\u001b[0m \u001b[39m# parameters are validated in fit_predict\u001b[39;00m\n\u001b[0;32m--> 186\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mfit_predict(X, y)\n\u001b[1;32m    187\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/sklearn/mixture/_base.py:218\u001b[0m, in \u001b[0;36mBaseMixture.fit_predict\u001b[0;34m(self, X, y)\u001b[0m\n\u001b[1;32m    190\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Estimate model parameters using X and predict the labels for X.\u001b[39;00m\n\u001b[1;32m    191\u001b[0m \n\u001b[1;32m    192\u001b[0m \u001b[39mThe method fits the model n_init times and sets the parameters with\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[39m    Component labels.\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    216\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_params()\n\u001b[0;32m--> 218\u001b[0m X \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_data(X, dtype\u001b[39m=\u001b[39;49m[np\u001b[39m.\u001b[39;49mfloat64, np\u001b[39m.\u001b[39;49mfloat32], ensure_min_samples\u001b[39m=\u001b[39;49m\u001b[39m2\u001b[39;49m)\n\u001b[1;32m    219\u001b[0m \u001b[39mif\u001b[39;00m X\u001b[39m.\u001b[39mshape[\u001b[39m0\u001b[39m] \u001b[39m<\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mn_components:\n\u001b[1;32m    220\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\n\u001b[1;32m    221\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mExpected n_samples >= n_components \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    222\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mbut got n_components = \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mn_components\u001b[39m}\u001b[39;00m\u001b[39m, \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    223\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mn_samples = \u001b[39m\u001b[39m{\u001b[39;00mX\u001b[39m.\u001b[39mshape[\u001b[39m0\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    224\u001b[0m     )\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/sklearn/base.py:565\u001b[0m, in \u001b[0;36mBaseEstimator._validate_data\u001b[0;34m(self, X, y, reset, validate_separately, **check_params)\u001b[0m\n\u001b[1;32m    563\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mValidation should be done on X, y or both.\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    564\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39mnot\u001b[39;00m no_val_X \u001b[39mand\u001b[39;00m no_val_y:\n\u001b[0;32m--> 565\u001b[0m     X \u001b[39m=\u001b[39m check_array(X, input_name\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mX\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mcheck_params)\n\u001b[1;32m    566\u001b[0m     out \u001b[39m=\u001b[39m X\n\u001b[1;32m    567\u001b[0m \u001b[39melif\u001b[39;00m no_val_X \u001b[39mand\u001b[39;00m \u001b[39mnot\u001b[39;00m no_val_y:\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/sklearn/utils/validation.py:921\u001b[0m, in \u001b[0;36mcheck_array\u001b[0;34m(array, accept_sparse, accept_large_sparse, dtype, order, copy, force_all_finite, ensure_2d, allow_nd, ensure_min_samples, ensure_min_features, estimator, input_name)\u001b[0m\n\u001b[1;32m    915\u001b[0m         \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\n\u001b[1;32m    916\u001b[0m             \u001b[39m\"\u001b[39m\u001b[39mFound array with dim \u001b[39m\u001b[39m%d\u001b[39;00m\u001b[39m. \u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m expected <= 2.\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    917\u001b[0m             \u001b[39m%\u001b[39m (array\u001b[39m.\u001b[39mndim, estimator_name)\n\u001b[1;32m    918\u001b[0m         )\n\u001b[1;32m    920\u001b[0m     \u001b[39mif\u001b[39;00m force_all_finite:\n\u001b[0;32m--> 921\u001b[0m         _assert_all_finite(\n\u001b[1;32m    922\u001b[0m             array,\n\u001b[1;32m    923\u001b[0m             input_name\u001b[39m=\u001b[39;49minput_name,\n\u001b[1;32m    924\u001b[0m             estimator_name\u001b[39m=\u001b[39;49mestimator_name,\n\u001b[1;32m    925\u001b[0m             allow_nan\u001b[39m=\u001b[39;49mforce_all_finite \u001b[39m==\u001b[39;49m \u001b[39m\"\u001b[39;49m\u001b[39mallow-nan\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m    926\u001b[0m         )\n\u001b[1;32m    928\u001b[0m \u001b[39mif\u001b[39;00m ensure_min_samples \u001b[39m>\u001b[39m \u001b[39m0\u001b[39m:\n\u001b[1;32m    929\u001b[0m     n_samples \u001b[39m=\u001b[39m _num_samples(array)\n",
+      "File \u001b[0;32m~/miniconda3/envs/synthcity-all2/lib/python3.9/site-packages/sklearn/utils/validation.py:161\u001b[0m, in \u001b[0;36m_assert_all_finite\u001b[0;34m(X, allow_nan, msg_dtype, estimator_name, input_name)\u001b[0m\n\u001b[1;32m    144\u001b[0m \u001b[39mif\u001b[39;00m estimator_name \u001b[39mand\u001b[39;00m input_name \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mX\u001b[39m\u001b[39m\"\u001b[39m \u001b[39mand\u001b[39;00m has_nan_error:\n\u001b[1;32m    145\u001b[0m     \u001b[39m# Improve the error message on how to handle missing values in\u001b[39;00m\n\u001b[1;32m    146\u001b[0m     \u001b[39m# scikit-learn.\u001b[39;00m\n\u001b[1;32m    147\u001b[0m     msg_err \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m (\n\u001b[1;32m    148\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00mestimator_name\u001b[39m}\u001b[39;00m\u001b[39m does not accept missing values\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    149\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39m encoded as NaN natively. For supervised learning, you might want\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    159\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39m#estimators-that-handle-nan-values\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    160\u001b[0m     )\n\u001b[0;32m--> 161\u001b[0m \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(msg_err)\n",
+      "\u001b[0;31mValueError\u001b[0m: Input X contains NaN.\nBayesianGaussianMixture does not accept missing values encoded as NaN natively. For supervised learning, you might want to consider sklearn.ensemble.HistGradientBoostingClassifier and Regressor which accept missing values encoded as NaNs natively. Alternatively, it is possible to preprocess the data, for instance by using an imputer transformer in a pipeline or drop samples with missing values. See https://scikit-learn.org/stable/modules/impute.html You can find a list of all estimators that handle NaN values at the following page: https://scikit-learn.org/stable/modules/impute.html#estimators-that-handle-nan-values"
+     ]
+    }
+   ],
+   "source": [
+    "# synthcity absolute\n",
+    "from synthcity.plugins import Plugins\n",
+    "\n",
+    "syn_model = Plugins().get(\"ctgan\")\n",
+    "\n",
+    "syn_model.fit(loader)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Whoops! Here we see that Synthcity cannot handle NaN values. Proof that we need to impute first!"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lets Impute\n",
+    "First we can view the different possible Imputation plugins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['miwae',\n",
+       " 'sklearn_missforest',\n",
+       " 'miracle',\n",
+       " 'most_frequent',\n",
+       " 'hyperimpute',\n",
+       " 'EM',\n",
+       " 'gain',\n",
+       " 'median',\n",
+       " 'sklearn_ice',\n",
+       " 'mice',\n",
+       " 'mean',\n",
+       " 'ice',\n",
+       " 'missforest',\n",
+       " 'nop',\n",
+       " 'sinkhorn',\n",
+       " 'softimpute']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from hyperimpute.plugins.imputers import Imputers, ImputerPlugin\n",
+    "\n",
+    "imputers = Imputers()\n",
+    "imputers.list()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load an imputer\n",
+    "Imputers are loaded with `Imputers().get(method_name)`. Below we explain all the parameters we are using as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imputer = Imputers().get(\n",
+    "    \"hyperimpute\",  # the name of the imputation method.\n",
+    "    # The rest of the kwargs are specific to the method\n",
+    "    # optimizer: str. The optimizer to use: simple, hyperband, bayesian\n",
+    "    optimizer=\"hyperband\",\n",
+    "    # classifier_seed: list. Model search pool for categorical columns.\n",
+    "    classifier_seed=[\"logistic_regression\", \"catboost\", \"xgboost\", \"random_forest\"],\n",
+    "    # regression_seed: list. Model search pool for continuous columns.\n",
+    "    regression_seed=[\n",
+    "        \"linear_regression\",\n",
+    "        \"catboost_regressor\",\n",
+    "        \"xgboost_regressor\",\n",
+    "        \"random_forest_regressor\",\n",
+    "    ],\n",
+    "    # class_threshold: int. how many max unique items must be in the column to be is associated with categorical\n",
+    "    class_threshold=5,\n",
+    "    # imputation_order: int. 0 - ascending, 1 - descending, 2 - random\n",
+    "    imputation_order=2,\n",
+    "    # n_inner_iter: int. number of imputation iterations\n",
+    "    n_inner_iter=10,\n",
+    "    # select_model_by_column: bool. If true, select a different model for each column. Else, it reuses the model chosen for the first column.\n",
+    "    select_model_by_column=True,\n",
+    "    # select_model_by_iteration: bool. If true, selects new models for each iteration. Else, it reuses the models chosen in the first iteration.\n",
+    "    select_model_by_iteration=True,\n",
+    "    # select_lazy: bool. If false, starts the optimizer on every column unless other restrictions apply. Else, if for the current iteration there is a trend(at least to columns of the same type got the same model from the optimizer), it reuses the same model class for all the columns without starting the optimizer.\n",
+    "    select_lazy=True,\n",
+    "    # select_patience: int. How many iterations without objective function improvement to wait.\n",
+    "    select_patience=5,\n",
+    ")\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Impute the missing values\n",
+    "We impute the missing values with `imputer.fit_transform()`, which is a style you may be familiar with from library `sklearn`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>bmi</th>\n",
+       "      <th>bp</th>\n",
+       "      <th>s1</th>\n",
+       "      <th>s2</th>\n",
+       "      <th>s3</th>\n",
+       "      <th>s4</th>\n",
+       "      <th>s5</th>\n",
+       "      <th>s6</th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.038076</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>0.061696</td>\n",
+       "      <td>0.036598</td>\n",
+       "      <td>-0.028982</td>\n",
+       "      <td>-0.034821</td>\n",
+       "      <td>-0.043401</td>\n",
+       "      <td>-0.002592</td>\n",
+       "      <td>0.019907</td>\n",
+       "      <td>-0.017646</td>\n",
+       "      <td>235.281221</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-0.001882</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>-0.051474</td>\n",
+       "      <td>-0.026328</td>\n",
+       "      <td>-0.008449</td>\n",
+       "      <td>-0.019163</td>\n",
+       "      <td>0.074412</td>\n",
+       "      <td>-0.039493</td>\n",
+       "      <td>-0.068332</td>\n",
+       "      <td>-0.092204</td>\n",
+       "      <td>75.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.085299</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>0.044451</td>\n",
+       "      <td>0.008739</td>\n",
+       "      <td>-0.045599</td>\n",
+       "      <td>-0.043475</td>\n",
+       "      <td>-0.032356</td>\n",
+       "      <td>-0.002592</td>\n",
+       "      <td>0.002861</td>\n",
+       "      <td>-0.025930</td>\n",
+       "      <td>141.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>-0.014735</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>0.019753</td>\n",
+       "      <td>-0.036656</td>\n",
+       "      <td>0.012191</td>\n",
+       "      <td>0.017234</td>\n",
+       "      <td>-0.036038</td>\n",
+       "      <td>0.034309</td>\n",
+       "      <td>0.022688</td>\n",
+       "      <td>-0.009362</td>\n",
+       "      <td>206.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.005383</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>-0.036385</td>\n",
+       "      <td>0.021872</td>\n",
+       "      <td>-0.022235</td>\n",
+       "      <td>-0.023615</td>\n",
+       "      <td>0.008142</td>\n",
+       "      <td>-0.034137</td>\n",
+       "      <td>-0.031988</td>\n",
+       "      <td>-0.003815</td>\n",
+       "      <td>95.123352</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>437</th>\n",
+       "      <td>0.041708</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>0.019662</td>\n",
+       "      <td>0.059744</td>\n",
+       "      <td>-0.005697</td>\n",
+       "      <td>-0.002566</td>\n",
+       "      <td>-0.028674</td>\n",
+       "      <td>0.020585</td>\n",
+       "      <td>0.031193</td>\n",
+       "      <td>0.007207</td>\n",
+       "      <td>178.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>438</th>\n",
+       "      <td>-0.005515</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>-0.015906</td>\n",
+       "      <td>-0.006105</td>\n",
+       "      <td>0.071843</td>\n",
+       "      <td>0.079165</td>\n",
+       "      <td>-0.028674</td>\n",
+       "      <td>0.034309</td>\n",
+       "      <td>-0.018114</td>\n",
+       "      <td>0.044485</td>\n",
+       "      <td>123.368382</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>439</th>\n",
+       "      <td>0.041708</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>-0.015906</td>\n",
+       "      <td>0.017293</td>\n",
+       "      <td>-0.037344</td>\n",
+       "      <td>-0.024482</td>\n",
+       "      <td>0.019257</td>\n",
+       "      <td>-0.011080</td>\n",
+       "      <td>-0.046883</td>\n",
+       "      <td>0.015491</td>\n",
+       "      <td>132.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>440</th>\n",
+       "      <td>-0.045472</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>0.039062</td>\n",
+       "      <td>0.001215</td>\n",
+       "      <td>0.016318</td>\n",
+       "      <td>0.015283</td>\n",
+       "      <td>-0.030381</td>\n",
+       "      <td>0.024658</td>\n",
+       "      <td>0.044529</td>\n",
+       "      <td>-0.025930</td>\n",
+       "      <td>220.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>441</th>\n",
+       "      <td>-0.045472</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>-0.073030</td>\n",
+       "      <td>-0.081413</td>\n",
+       "      <td>0.083740</td>\n",
+       "      <td>0.027809</td>\n",
+       "      <td>0.173816</td>\n",
+       "      <td>-0.039493</td>\n",
+       "      <td>-0.004222</td>\n",
+       "      <td>-0.036032</td>\n",
+       "      <td>57.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>442 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          age       sex       bmi        bp        s1        s2        s3  \\\n",
+       "0    0.038076  0.050680  0.061696  0.036598 -0.028982 -0.034821 -0.043401   \n",
+       "1   -0.001882 -0.044642 -0.051474 -0.026328 -0.008449 -0.019163  0.074412   \n",
+       "2    0.085299  0.050680  0.044451  0.008739 -0.045599 -0.043475 -0.032356   \n",
+       "3   -0.014735 -0.044642  0.019753 -0.036656  0.012191  0.017234 -0.036038   \n",
+       "4    0.005383 -0.044642 -0.036385  0.021872 -0.022235 -0.023615  0.008142   \n",
+       "..        ...       ...       ...       ...       ...       ...       ...   \n",
+       "437  0.041708  0.050680  0.019662  0.059744 -0.005697 -0.002566 -0.028674   \n",
+       "438 -0.005515  0.050680 -0.015906 -0.006105  0.071843  0.079165 -0.028674   \n",
+       "439  0.041708  0.050680 -0.015906  0.017293 -0.037344 -0.024482  0.019257   \n",
+       "440 -0.045472 -0.044642  0.039062  0.001215  0.016318  0.015283 -0.030381   \n",
+       "441 -0.045472 -0.044642 -0.073030 -0.081413  0.083740  0.027809  0.173816   \n",
+       "\n",
+       "           s4        s5        s6      target  \n",
+       "0   -0.002592  0.019907 -0.017646  235.281221  \n",
+       "1   -0.039493 -0.068332 -0.092204   75.000000  \n",
+       "2   -0.002592  0.002861 -0.025930  141.000000  \n",
+       "3    0.034309  0.022688 -0.009362  206.000000  \n",
+       "4   -0.034137 -0.031988 -0.003815   95.123352  \n",
+       "..        ...       ...       ...         ...  \n",
+       "437  0.020585  0.031193  0.007207  178.000000  \n",
+       "438  0.034309 -0.018114  0.044485  123.368382  \n",
+       "439 -0.011080 -0.046883  0.015491  132.000000  \n",
+       "440  0.024658  0.044529 -0.025930  220.000000  \n",
+       "441 -0.039493 -0.004222 -0.036032   57.000000  \n",
+       "\n",
+       "[442 rows x 11 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x_imputed = imputer.fit_transform(df.copy())\n",
+    "display(x_imputed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = GenericDataLoader(\n",
+    "    x_imputed,\n",
+    "    target_column=\"target\",\n",
+    "    sensitive_columns=[\"sex\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 50%|████▉     | 999/2000 [00:26<00:26, 37.12it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<synthcity.plugins.generic.plugin_ctgan.CTGANPlugin at 0x7fc86419a8b0>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# synthcity absolute\n",
+    "from synthcity.plugins import Plugins\n",
+    "\n",
+    "syn_model = Plugins().get(\"ctgan\")\n",
+    "\n",
+    "syn_model.fit(loader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>bmi</th>\n",
+       "      <th>bp</th>\n",
+       "      <th>s1</th>\n",
+       "      <th>s2</th>\n",
+       "      <th>s3</th>\n",
+       "      <th>s4</th>\n",
+       "      <th>s5</th>\n",
+       "      <th>s6</th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.041995</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>-0.064871</td>\n",
+       "      <td>0.003832</td>\n",
+       "      <td>-0.063335</td>\n",
+       "      <td>-0.021692</td>\n",
+       "      <td>0.049292</td>\n",
+       "      <td>-0.011233</td>\n",
+       "      <td>-0.061892</td>\n",
+       "      <td>-0.005036</td>\n",
+       "      <td>178.708153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-0.010442</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>-0.053701</td>\n",
+       "      <td>-0.045700</td>\n",
+       "      <td>-0.035140</td>\n",
+       "      <td>-0.046954</td>\n",
+       "      <td>-0.003534</td>\n",
+       "      <td>-0.045670</td>\n",
+       "      <td>-0.028287</td>\n",
+       "      <td>-0.059116</td>\n",
+       "      <td>158.288506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>-0.012305</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>0.014011</td>\n",
+       "      <td>0.053512</td>\n",
+       "      <td>-0.016200</td>\n",
+       "      <td>-0.031202</td>\n",
+       "      <td>-0.047944</td>\n",
+       "      <td>0.026379</td>\n",
+       "      <td>0.035810</td>\n",
+       "      <td>0.016790</td>\n",
+       "      <td>274.051639</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>-0.107226</td>\n",
+       "      <td>-0.044642</td>\n",
+       "      <td>-0.047236</td>\n",
+       "      <td>-0.070500</td>\n",
+       "      <td>-0.019622</td>\n",
+       "      <td>-0.032736</td>\n",
+       "      <td>0.020071</td>\n",
+       "      <td>-0.041136</td>\n",
+       "      <td>-0.019809</td>\n",
+       "      <td>-0.027935</td>\n",
+       "      <td>179.073245</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.012606</td>\n",
+       "      <td>0.050680</td>\n",
+       "      <td>-0.000232</td>\n",
+       "      <td>0.034475</td>\n",
+       "      <td>0.021446</td>\n",
+       "      <td>0.040235</td>\n",
+       "      <td>-0.023840</td>\n",
+       "      <td>-0.006283</td>\n",
+       "      <td>0.010178</td>\n",
+       "      <td>0.102730</td>\n",
+       "      <td>309.017383</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        age       sex       bmi        bp        s1        s2        s3  \\\n",
+       "0  0.041995  0.050680 -0.064871  0.003832 -0.063335 -0.021692  0.049292   \n",
+       "1 -0.010442 -0.044642 -0.053701 -0.045700 -0.035140 -0.046954 -0.003534   \n",
+       "2 -0.012305  0.050680  0.014011  0.053512 -0.016200 -0.031202 -0.047944   \n",
+       "3 -0.107226 -0.044642 -0.047236 -0.070500 -0.019622 -0.032736  0.020071   \n",
+       "4  0.012606  0.050680 -0.000232  0.034475  0.021446  0.040235 -0.023840   \n",
+       "\n",
+       "         s4        s5        s6      target  \n",
+       "0 -0.011233 -0.061892 -0.005036  178.708153  \n",
+       "1 -0.045670 -0.028287 -0.059116  158.288506  \n",
+       "2  0.026379  0.035810  0.016790  274.051639  \n",
+       "3 -0.041136 -0.019809 -0.027935  179.073245  \n",
+       "4 -0.006283  0.010178  0.102730  309.017383  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "X_syn = syn_model.generate(count=df_.shape[0]).dataframe()\n",
+    "display(X_syn.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+cAAAMuCAYAAAB7GXLAAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAACwOUlEQVR4nOzde3hU5bn38V9AQEQSooIISYQISqQQEoJWoI1IsyN7l1agGmprPRSVg7sFq4K2bmS7KyBq8YBia6vWFgmVw1vbIk1Ro6I1CYRoa1BOOgmiHAwJogKGvH+MM5nDWpM1ycysWTPfz3XlgnnWmskjJjPrXs/93HdKS0tLiwAAAAAAgG062T0BAAAAAACSHcE5AAAAAAA2IzgHAAAAAMBmBOcAAAAAANiM4BwAAAAAAJsRnAMAAAAAYDOCcwAAAAAAbEZwDgAAAACAzU6yewKxdOLECX344Yfq2bOnUlJS7J4OAAAAACDBtbS06PDhw+rXr586dTJfH0+q4PzDDz9UZmam3dMAAAAAACSZuro6ZWRkmB53THDe3Nysu+66S3/4wx/00UcfqV+/frrmmmv0i1/8wvIqeM+ePSW5/1FSU1OjOV0AAAAAANTU1KTMzExvPGrGMcH54sWL9dhjj+npp5/W0KFDVVVVpWuvvVZpaWn6yU9+Yuk1PEF8amoqwTkAAAAAIGbaWlR2THD++uuv67vf/a7+67/+S5I0YMAAPfvss6qoqLB5ZgAAAAAAdIxjqrWPHj1aGzdu1HvvvSdJqqmp0WuvvaYJEyaYPufo0aNqamry+wIAAAAAIN44ZuV83rx5ampq0pAhQ9S5c2c1Nzfrl7/8pX7wgx+YPmfhwoVasGBBDGcJAAAAAED4HBOcr1q1Sn/84x+1YsUKDR06VFu3btXs2bPVr18/XX311YbPuf3223XzzTd7H3s24relublZx48fj9jckby6dOmizp072z0NAAAAAHEupaWlpcXuSViRmZmpefPmadasWd6x//u//9Mf/vAHbdu2zdJrNDU1KS0tTY2NjYYF4VpaWvTRRx/p0KFDkZo2oF69eqlv376WuwoAAAAASBxtxaEejlk5/+yzz4Iatnfu3FknTpyI2PfwBOZ9+vTRKaecQjCFDmlpadFnn32mffv2SZLOOussm2cEAAAAIF45JjifOHGifvnLXyorK0tDhw5VdXW1HnjgAV133XURef3m5mZvYH766adH5DWB7t27S5L27dunPn36kOIOAAAAwJBjgvOHH35Yd955p2bOnKl9+/apX79+uvHGG/U///M/EXl9zx7zU045JSKvB3h4fqaOHz9OcA4AAADAkGOC8549e2rp0qVaunRpVL8PqeyINH6mAAAAALTFMX3OAQAAAABIVATnsOSaa67RZZddFtZznnrqKfXq1Ssq8wEAAACAREJw7nDXXHONUlJSlJKSoi5dumjgwIG67bbb9MUXX9g9tXYZMGBA1LcuAAAAAEC8ccyec5i79NJL9eSTT+r48ePavHmzrr76aqWkpGjx4sV2Tw0AAAAAYAEr5wmgW7du6tu3rzIzM3XZZZfpW9/6lsrKyrzHT5w4oYULF2rgwIHq3r27cnNz9dxzz3mPNzc368c//rH3+HnnnacHH3ww7Hk89dRTysrK0imnnKJJkybp4MGDfsd37typ7373uzrzzDN16qmnatSoUfrHP/7hPX7xxRfrgw8+0Jw5c7zZAJJ08OBBff/731f//v11yimnaNiwYXr22WfDnh8AAAAAxCuC8yiodjVozZZ6VbsaYv69//Wvf+n1119X165dvWMLFy7U73//ey1fvlz//ve/NWfOHP3whz9UeXm5JHfwnpGRoT/96U9655139D//8z+64447tGrVKsvf980339SPf/xj3XTTTdq6davGjRun//u///M759NPP9V//ud/auPGjaqurtall16qiRMnyuVySZLWrFmjjIwM/e///q/27t2rvXv3SpK++OILjRw5Un/961/1r3/9SzfccIOuuuoqVVRUdPSfCwAAAADiQkpLS0uL3ZOIlaamJqWlpamxsVGpqal+x7744gvt3r1bAwcO1Mknn9zu77Fofa2Wl+/yPp5emK15E3La/Xptueaaa/SHP/xBJ598sr788ksdPXpUnTp10qpVqzRlyhQdPXpUp512mv7xj3/ooosu8j5v2rRp+uyzz7RixQrD173pppv00UcfeVfYr7nmGh06dEjr1q0zPP/KK69UY2Oj/vrXv3rHpk6dqhdeeEGHDh0ynf/XvvY1TZ8+XTfddJMk957z2bNna/bs2SH/u7/97W9ryJAhuu+++0KeFw8i9bMFAAAAwHlCxaG+2HMeQdWuBr/AXJKWl+9S8dC+ystKj9r3HTdunB577DEdOXJEv/rVr3TSSSdpypQpkqQdO3bos88+U1FRkd9zjh07pry8PO/jZcuW6Xe/+51cLpc+//xzHTt2TCNGjLA8h9raWk2aNMlv7KKLLtILL7zgffzpp5/qrrvu0l//+lft3btXX375pT7//HPvyrmZ5uZm3XPPPVq1apX27NmjY8eO6ejRozrllFMszw8AAAAA4hnBeQTtPnDEdDyawXmPHj00aNAgSdLvfvc75ebm6re//a1+/OMf69NPP5Uk/fWvf1X//v39ntetWzdJ0sqVK3XLLbfo/vvv10UXXaSePXtqyZIlevPNNyM6z1tuuUVlZWW67777NGjQIHXv3l3f+973dOzYsZDPW7JkiR588EEtXbpUw4YNU48ePTR79uw2nwcAAAAATkFwHkEDz+gR1ng0dOrUSXfccYduvvlmXXnllTr//PPVrVs3uVwuFRYWGj5n06ZNGj16tGbOnOkd27lzZ1jfNycnJyiY/+c//xn0fa655hrvCvunn36q999/3++crl27qrm5Oeh53/3ud/XDH/5QknuP/Hvvvafzzz8/rDkCAAAAQLyiIFwE5WWla3phtt/YjMLsqK6aG7n88svVuXNnLVu2TD179tQtt9yiOXPm6Omnn9bOnTu1ZcsWPfzww3r66aclSYMHD1ZVVZU2bNig9957T3feeacqKyvD+p4/+clP9MILL+i+++7T9u3b9cgjj/iltHu+z5o1a7R161bV1NToyiuv1IkTJ/zOGTBggF555RXt2bNHBw4c8D6vrKxMr7/+umpra3XjjTfq448/7sC/EAAAAADEF4LzCJs3IUdrZ47WA1fkau3M0ZobxWJwZk466STddNNNuvfee3XkyBHdfffduvPOO7Vw4ULl5OTo0ksv1V//+lcNHDhQknTjjTdq8uTJKikp0YUXXqiDBw/6raJb8fWvf12/+c1v9OCDDyo3N1d///vf9Ytf/MLvnAceeEDp6ekaPXq0Jk6cqOLiYuXn5/ud87//+796//33dc4556h3796SpF/84hfKz89XcXGxLr74YvXt21eXXXZZ+/+BAAAAACDOUK39K1TURrTwswUAAAAkL6vV2lk5BwAAAADAZgTnAAAAAADYjOAcAAAAAACbEZwDAAAAAGAzgnMAAAAAAGxGcA4AAAAAgM0IzgEAAAAAsNlJdk8AAAAA8Kqvkg7ukE4fJGUUBD8GgARFcA4AAIDY8Q22Jf/Au2y+tGlp67n9R0p7Nrc+Hl4iTf51TKcLALFCcI52u+uuu7Ru3Tpt3bo14q998cUXa8SIEVq6dGnEXnPAgAGaPXu2Zs+eHbHXBAAAYQgMvn0NL5HeKvUf8w3MpdbjBOgAEhB7zh1u//79mjFjhrKystStWzf17dtXxcXF2rRpU0S/T0pKitatWxfR15Skl19+WSkpKTp06JDf+Jo1a3T33XdH/PuF46mnnlKvXr1snQMAAI5VXyXVrJS2PNP6p1lgLgUH5qHOq6+KyBQBIJ6wcu5wU6ZM0bFjx/T0008rOztbH3/8sTZu3KiDBw/aPbUOOe200+yeAgAAaK9QK+SRcHAH+88BJBxWzh3s0KFDevXVV7V48WKNGzdOZ599ti644ALdfvvt+s53viNJuu666/Ttb3/b73nHjx9Xnz599Nvf/laSO4X8Jz/5iW677Taddtpp6tu3r+666y7v+QMGDJAkTZo0SSkpKd7HHs8884wGDBigtLQ0TZ06VYcPH/YeO3HihBYuXKiBAweqe/fuys3N1XPPPSdJev/99zVu3DhJUnp6ulJSUnTNNdd45+Sbfn706FHNnTtXmZmZ6tatmwYNGuSdv5F9+/Zp4sSJ6t69uwYOHKg//vGPQec88MADGjZsmHr06KHMzEzNnDlTn376qST3iv61116rxsZGpaSkKCUlxftv8swzz6igoEA9e/ZU3759deWVV2rfvn2mcwEAIKnUV0U3MJek5uPu1XhW0AEkEILzaPCkcUX5A+PUU0/VqaeeqnXr1uno0aOG50ybNk0vvPCC9u7d6x37y1/+os8++0wlJSXesaefflo9evTQm2++qXvvvVf/+7//q7KyMklSZWWlJOnJJ5/U3r17vY8laefOnVq3bp3+8pe/6C9/+YvKy8u1aNEi7/GFCxfq97//vZYvX65///vfmjNnjn74wx+qvLxcmZmZWr16tSTp3Xff1d69e/Xggw8a/nf86Ec/0rPPPquHHnpItbW1evzxx3Xqqaea/ttcc801qqur00svvaTnnntOjz76aFAA3alTJz300EP697//raefflovvviibrvtNknS6NGjtXTpUqWmpmrv3r3au3evbrnlFknumxt33323ampqtG7dOr3//vvemwoAACS98nvb97wxc6Qxs4PHhpf4j/UvkP58k7T2RumJ8e5VegBIAKS1R1pgGteY2VLRgqh8q5NOOklPPfWUrr/+ei1fvlz5+fkqLCzU1KlTNXz4cEnuIPO8887TM8884w08n3zySV1++eV+we3w4cM1f777w23w4MF65JFHtHHjRhUVFal3796SpF69eqlv375+czhx4oSeeuop9ezZU5J01VVXaePGjfrlL3+po0eP6p577tE//vEPXXTRRZKk7Oxsvfbaa3r88cdVWFjoTV/v06eP6f7u9957T6tWrVJZWZm+9a1veV/HzHvvvaf169eroqJCo0aNkiT99re/VU5Ojt95vivzAwYM0P/93/9p+vTpevTRR9W1a1elpaUpJSUl6L/5uuuu8/49OztbDz30kEaNGqVPP/005A0DAAASXn2VtH1D6HO+84jUuYtxtXZJypkYPHbBDe6x5uPuwNzXpqXu55DmDsDhWDmPJKM0rk1Lo7qCPmXKFH344Yf685//rEsvvVQvv/yy8vPz9dRTT3nPmTZtmp588klJ0scff6z169f7BZiSvMG8x1lnnWUpVXvAgAHewDzweTt27NBnn32moqIi7yr/qaeeqt///vfauXOn5f/GrVu3qnPnziosLLR0fm1trU466SSNHDnSOzZkyJCg4P8f//iHxo8fr/79+6tnz5666qqrdPDgQX322WchX3/z5s2aOHGisrKy1LNnT++8XC6X5f8mAAAS0sEdoY+PmSPlXyXlTnUH0xkFrX/3CDXWuUv7vi8AOADBeSSZfTBE+QPj5JNPVlFRke688069/vrruuaaa7yr4JI7JXzXrl1644039Ic//EEDBw7UN77xDb/X6NLF/8MuJSVFJ06caPN7h3qeZ//2X//6V23dutX79c4773j3nVvRvXt3y+da9f777+vb3/62hg8frtWrV2vz5s1atmyZJOnYsWOmzzty5IiKi4uVmpqqP/7xj6qsrNTatWvbfB4AAEnBsxoeqHCeNG2jVHRXdF7fbBwAHITgPJLi5APj/PPP15EjR1q//emn67LLLtOTTz6pp556Stdee23Yr9mlSxc1NzeHPY9u3brJ5XJp0KBBfl+ZmZmSpK5du0pSyNceNmyYTpw4ofLyckvfd8iQIfryyy+1eXNrb9R3333Xr13b5s2bdeLECd1///36+te/rnPPPVcffvih3+t07do1aF7btm3TwYMHtWjRIn3jG9/QkCFDKAYHAIDkzhQ8uCN4j/iYOdK42yOTdp5RYLwvnZR2AAmAPeeR5PnA8NtzHr0PjIMHD+ryyy/Xddddp+HDh6tnz56qqqrSvffeq+9+97t+506bNk3f/va31dzcrKuvvjrs7zVgwABt3LhRY8aMUbdu3ZSent7mc3r27KlbbrlFc+bM0YkTJzR27Fg1NjZq06ZNSk1N1dVXX62zzz5bKSkp+stf/qL//M//VPfu3YP2bQ8YMEBXX321rrvuOj300EPKzc3VBx98oH379umKK64I+r7nnXeeLr30Ut1444167LHHdNJJJ2n27Nl+K/CDBg3S8ePH9fDDD2vixInatGmTli9fHvR9P/30U23cuFG5ubk65ZRTlJWVpa5du+rhhx/W9OnT9a9//cv2fuwAANiqvkracIdU92br2PAS6ZxL/PeNR0rRgtZ96c3H3anu9VUE6AAcj5XzSCta4E7bmvR4ZNK3Qjj11FN14YUX6le/+pW++c1v6mtf+5ruvPNOXX/99XrkkUf8zv3Wt76ls846S8XFxerXr1/Y3+v+++9XWVmZMjMzlZeXZ/l5d999t+68804tXLhQOTk5uvTSS/XXv/5VAwcOlCT1799fCxYs0Lx583TmmWfqpptuMnydxx57TN/73vc0c+ZMDRkyRNdff71fdkCgJ598Uv369VNhYaEmT56sG264QX369PEez83N1QMPPKDFixfra1/7mv74xz9q4cKFfq8xevRoTZ8+XSUlJerdu7fuvfde9e7dW0899ZT+9Kc/6fzzz9eiRYt03333Wf73AAAgoZTNd1dM9w3MJemt0ugE5h4ZBdK+Wqq2A0goKS0tLS12TyJWmpqalJaWpsbGRqWmpvod++KLL7R7924NHDhQJ598sk0zjJ5PP/1U/fv315NPPqnJkyfbPZ2kkug/WwCAJFVf5Q6KzUx63F3ELZbfe9pGVtABxJ1QcagvVs4T3IkTJ7Rv3z7dfffd6tWrl77zne/YPSUAAOAU9VVSzUrjzjNtFbw1q7kT6jWtMvve7e2xDgBxgD3nCc7lcmngwIHKyMjQU089pZNO4n85AAAJz1OcrSOp5WXzA+rozHZv3/MIVfB2+FTj7xv4msNLWnuYhzNXs++9fQP7zwE4FpFaghswYICSaOcCAABYc4N7z7dHuMXZ6quk7WX+QbTkfpwzsfU1jArhSu7A/ILr3avjnoJtnmA68Ny3Sv3nGngDwExGgZR5YfBed8kd6BOcA3AggnMAAIBEERiYS/4BcFvBb+DKdqDAwNdTOX17mfvx4CKp9nnj/eCDi9uef+ANgFDzNArMpdYbAVuekfZslvqPlPKvavt7A4DNCM4BAAASQX1VcGAeyCj49QSxp5weOjCXjNPJMwpaX6++yvw1tm8I/doeba18h/oenha2v7nE/d8kSZufdH9d/6K17w8ANiE4D3DixAm7p4AEw88UACAm2irQ5nteRoE7yF39Y6nhfWvP8wS+HZmDWSq6r1B72UN9j8J50rjbW282+Nqz2T3OCjqAOEZw/pWuXbuqU6dO+vDDD9W7d2917dpVKSkpdk8LDtbS0qJjx45p//796tSpk7p27Wr3lAAAiaytoNb3vLbS130VznOnq1vZx93WHIrvkSp+bb7C77kB4Nn3Lrm/t9RaNG6nyQq457zAwNxjz2aCcwBxjeD8K506ddLAgQO1d+9effjhh3ZPBwnklFNOUVZWljp1onMhACCKjAq09R4i7d/W+nhwsbSv1npgPmaOezW6I3PwfS1PCrxvhXbJv1p74I2D8kVtf1/f6vD9R7rT2AP1HxmZKvYAECUpLUlUyttK8/eWlhZ9+eWXam5ujvHskIg6d+6sk046iSwMAEB0GAWbgWP1Ve7+31b3fH/jFumMwR0LYD1z8K3WbrVSvFExubZMelzKndr62HfPuST1L5AGjA3dGg4AosRKHCqxch4kJSVFXbp0UZcuXeyeCgAAgDmzPuS+Bdo8rAbm/Quk8Xd2fG5Gc7DC6r75QIHp9Ne/6F+tvU9OcNC/aan7eeHcPACAKCI4BwAAcBqjiuVmbcisBrzfuCUygXlHWN0378usUF3+Va17zGtWGj/3zzf5vM5sVtIB2IrgHAAAwGnMAm6jNmRWAt4xc+wPzKXQe9Y9xsyRcr4d3t5xK/8GnpV0isYBsAnBOQAAgNOYBZtmfcgDA972BLixUrTAnQFgVq3dM9dw5mwl6JfcK+kHd7CCDsAWFIQDAABwoqA953OkorvMz6dSeeu/wZbfSx9sMj9v2kb/fyP+7QB0AAXhAAAAEplnhdlq0NjeIm2JxPNv0Hw8dHBe/YfW880K7wFAhLFyDgAAgOQT2G7NyPAS6a3S4PHAlXUACMFqHNophnMCAABAR9VXuauP11fZPRNnu/5F6TuPSGcOMz/HKDCX2t/yDQBCIK0dAADAKcJNsWavdGiedmv1Ve5U9s1PWntee1q+AUAbCM4BAACcIJze5hJ7pcPh+fezEpxnXti6cs4NDwARRFo7AACAE4TqbR5oyzPGgTyp8OY87dbaUvemtPZG6Ynx7hsgABAhBOcAAABOYJZK3Xzcfx/6mhvc/bqNsFc6tKIF7mJvhfOsnc8NDwARRFo7AACAE3hWdgNXxM0CcSPslW5bRkF4NzEO7iC9HUBEsHIOAADgFEUL3BXG22PMHIJIq8K5idF8PHrzAJBUCM4BAADinSdtfcszbffmNvKdR6SiuyI+rYRltP98cLHxuZ27RH06AJIDae0AAADxLLDqeriGT3W3C0N4iha4K+F7WtFJ0vYNweexVQBAhBCcAwAAxCuj9mnhGD5Vmvx4xKaTdDIK/LcCBO75Z6sAgAgiOAcAAIhXG+4IfXzktVLeD91/913h9fydwLHj6qta/z0DV9N9/309Ww76jyRTAUC7pLS0tLTYPYlYaWpqUlpamhobG5Wammr3dAAAAMytuUF6qzT0OdM2EoBHU+CWgjGz3QF6oN9c4l8LoP9I6foXoz07AA5hNQ6lIBwAAEC8qa9qOzAnpTq6jLYUGPU1NyrSt2ezexwAwkBwDgAAEG9C9dkunOdeMaf6enSZ/T8IHDernt+eqvoAkhrBOQAAQLwxqwA+fKo07nZWzGPB7P9BYF/z/iONzzMbBwATBOcAAADxxqjPNpXXY8vo/4Ek/fkm9150j/yrggPx/gUUhQMQNgrCAQAAxCvfSuGslttjyzPugDxQYDE+z97zU06XzhjM/zMAXlbjUFqpAQAAxKvAPtuIvc5djMcP7vD/f5N/lXvs1ftax8yquwOAAdLaAQAAADNme88Dx61WdwcAEwTnAAAAdqqvkmpWEsTFK6O950Zt7KxWdwcAE6S1AwAA2KVsvv9qK2nQ8alogZQzMfT+f6sr7ABggpVzAAAAO5AG7SwZBVLuVPMaAFZX2AHABCvnAAAAdgiVBk1A50xWVtgBwATBOQAAgB1Ig05MVNgH0E6ktQMAAMRKfZX00kL3l0QaNADAi5VzAACAWAgs/la+yB2cT9tIGjQAgOAcAAAg6oyKv0nusZyJ7kJjcKb6KuObK2bjAGCC4BwAACDayu81P0YBOOcya4VHizwA7UBwDgAAEE31VdL2DebHKQDnTKat8CqlDzYFj+dM5CYMgJAoCAcAABBN28vMj1EAzrnMWuEFBuZtnQ8AX2HlHAAAIFoC05t9fecRKf+qmE4HERRuxgMZEgDawMo5AABANJgVgZPcK+YE5s6WURDcCs8MGRIALGDlHAAAIBrM0pgL50njbo/tXBAdRQvce8k3Py1V/z74+LkTpLNypcFFsZ8bAMdh5RwAACAaDmw3HidQSywZBdJ3H5b6j/QfP/VM6b317n72T4x3b3EAgBBYOQcAAIi031wi7dkcPE56c+K6/kVpyzPu/++nnC69ep//cSq2A2gDK+cAAACRtPFu48D8G7dIRXfFfDqIofyrpIlLpTMGGx+nYjuAEBwVnO/Zs0c//OEPdfrpp6t79+4aNmyYqqqq7J4WAACAW9n84BVTj88OxnYusI9ZZXYqtgMIwTHBeUNDg8aMGaMuXbpo/fr1euedd3T//fcrPT3d7qkBAACErs4uBe9JRuIyquTOlgYAbXDMnvPFixcrMzNTTz75pHds4MCBNs4IAADAR/m95sf6F9A6Ldl4Krkf3OFeMScwB9AGx6yc//nPf1ZBQYEuv/xy9enTR3l5efrNb34T8jlHjx5VU1OT3xcAAEDE1VdJ2zcYH/vGLdL1G2M7H8SHjAIpdyqBOQBLHBOc79q1S4899pgGDx6sDRs2aMaMGfrJT36ip59+2vQ5CxcuVFpamvcrMzMzhjMGAABJw6zQ1+BiafydsZ0L4k99lVSz0v0nAJhIaWlpabF7ElZ07dpVBQUFev31171jP/nJT1RZWak33njD8DlHjx7V0aNHvY+bmpqUmZmpxsZGpaamRn3OAAAgSdRXuXtZB5q2kVXTZFc2378WwZjZ7pR3AEmjqalJaWlpbcahjlk5P+uss3T++ef7jeXk5Mjlcpk+p1u3bkpNTfX7AgAAiKj6KvfK+fAS/3EKgMGoSOCmpaygAzDkmIJwY8aM0bvvvus39t577+nss8+2aUYAACDpBa6KDi+RzrmEAmBwM9vucHAHPx8Agjhm5XzOnDn65z//qXvuuUc7duzQihUr9Otf/1qzZs2ye2oAACAZGa2KvlVKYI5W9DsHEAbHBOejRo3S2rVr9eyzz+prX/ua7r77bi1dulQ/+MEP7J4aAABIRtvLjMfNVkuRfOh3DiAMjikIFwlWN+IDAACEFJjO7osicAjkqUtAVgWQlKzGoY7Zcw4AABAXjNLZPVgVhZGMAn4uALSJ4BwAACAcZmnrhfOkcbfHdi4AgIThmD3nAAAAccGsmNfgotjOAwCQUAjOAQAAwkGRLwBAFJDWDgAAYJWnsFfORPcXRb4AABFCcA4AAGBFYIX2MbOlogV2zQYAkGBIawcAAGiLUYX2TUvd4wAARADBOQAAQFvMKrSbjQMAECbS2gEAAHxteUbas1nqP1LKv8o9Zlah3WwcAIAwsXIOAADg8ZtLpD/fJG1+0v3nby5xj1OhHQAQZaycAwAASK0r5r72bHaP51/lLv5GhXYAQJQQnAMAAEjBgbnHey+0prdnFBCUIzI8bfm40QPgK6S1AwAASO495ka2/cXdRg2IlLL50hPjpbU3uv/k5wuACM4BAADcq5idu0i9hxgfp20aIoW2fABMkNYOAACSW9l8/2Cpz1Bp37+Dzzu4g/RjdNz2MvNxfr6ApMbKOQAASF5Gq5hGgblE2zQAQFQRnAMAgOR1cIfx+OBi/8e0TUOkDC4KbxxA0iCtHQAAJC+z1fDC29xt0/ZsdheK81RrBzoqo0AaM9s/Y4ObPwAkpbS0tLTYPYlYaWpqUlpamhobG5Wammr3dAAAQDwI3HM+Zo6kloCx2e4+50Ck0EoNSBpW41CCcwAAAN9ASXK3two0bSNBFAAgbFbjUPacAwAAZBRIuVPdf5rtQzcbBwAgAgjOAQAAfJntQ6daOwAgigjOAQAAfHkKdvmiYBcAIMqo1g4AABCoaIG7WjsFuwAAMUJwDgAAkptR1WwqaQMAYozgHAAAJK81N0hvlbY+9qSz00YNABBjBOcAACA5BQbmkn9Q7juWM5EVdABAVFEQDgAAJJ/6quDAPBTaqAEAoozgHAAAJJ/ye8M7nzZqAIAoIzgHAADJpb5K2r7B+vm0UQMAxAB7zgEAQHIJJ0W9cJ407vbozQUAgK+wcg4AAJJLOCnqg4uiNw8AAHwQnAMAgOQzuNj/8Zg5rW3UfMdIZwcAxAhp7QAAIHmUzfdvlza4WCq8rTUIz5noTns/fRCBOQAgplg5BwAAyaG+KriPeWBhuIwCKXcqgTkAIOYIzgEAQHIwKwRHD3MAQBwgOAcAAMnBrBAcPcwBAHGA4BwAACSHjAKKvgEA4hYF4QAAQPIoWkDRNwBAXCI4BwAAySWjgKAcABB3SGsHAAAAAMBmrJwDAIDEVl9FGjsAIO4RnAMAgMRVNt+/t/mY2e595wAAxBnS2gEAQGKqr/IPzCX34/oqO2YDAEBIBOcAACAxHdwR3jgAADYiOAcAAInp9EHhjQMAYCOCcwAAkJgyCtx7zH2NmUNROABAXKIgHAAASFxFC6SciVRrBwDEPYJzAACQ2DIKCMoBAHGPtHYAAAAAAGxGcA4AAAAAgM0IzgEAAAAAsBnBOQAAAAAANiM4BwAAAADAZgTnAAAAAADYjOAcAAAAAACbEZwDAAAAAGCzk+yeAAAAQIfUV0kHd0inD5IyCuyeDQAA7UJwDgAAnKtsvrRpaevjMbOlogV2zQYAgHYjrR0AADhTfZV/YC65H9dX2TEbAAA6hOAcAAA408Ed4Y0DABDHCM4BAIAznT4ovHEAAOIYwTkAAHCmjAL3HnNfY+ZQFA4A4EgUhAMAAM5VtEDKmUi1dgCA4xGcAwAAZ8soICgHADgeae0AAAAAANiM4BwAAAAAAJsRnAMAAAAAYDOCcwAAAAAAbEZBOAAA4Bz1VVRmBwAkJIJzAADgDGXzpU1LWx+Pme1upQYAQAIgrR0AAMS/+ir/wFxyP66vsmM2AABEHME5AACIf+X3Go8f3BHbeQAAECUE5wAAIL7VV0nbNxgfO31QbOcCAECUEJwDAID4ZrY6PriYonAAgIRBcA4AAOKb2ep44W2xnQcAAFFEcA4AAOJbRoG7MruvMXNYNQcAJBRaqQEAgPhXtEDKmUiPcwBAwiI4BwAA8am+yj8Y93wBAJCACM4BAIC96quk7WXuvw8ucgfgZfP9+5qPme1ePQcAIEERnAMAAPsEBuHli6TMC6W6N/3P27TUndbOyjkAIEFREA4AANijvso/MPcIDMw9zFqqAQCQAAjOAQCAPcINts1aqgEAkAAIzgEAgD3CCbZpnQYASHDsOQcAAPbw9C83Sm33KJzXWiQOAIAERnAOAADs4+lfvr1M2vWS/37zMXOkcbfbNzcAAGLIsWntixYtUkpKimbPnm33VAAAQEdkFLiD8B//XZq2UZr0uPvPorvsnhkAADHjyJXzyspKPf744xo+fLjdUwEAAJGUUUAKOwAgKTlu5fzTTz/VD37wA/3mN79Renq63dMBAADtUV8l1ax0/wkAAJwXnM+aNUv/9V//pW9961ttnnv06FE1NTX5fQEAAJuVzZeeGC+tvdH9Z9l8u2cEAIDtHBWcr1y5Ulu2bNHChQstnb9w4UKlpaV5vzIzM6M8QwAAEFJ9VXB19k1LWUEHACQ9xwTndXV1+ulPf6o//vGPOvnkky095/bbb1djY6P3q66uLsqzBAAAIR3cEd44AABJwjEF4TZv3qx9+/YpPz/fO9bc3KxXXnlFjzzyiI4eParOnTv7Padbt27q1q1brKcKAADMnD4ovHEAAJKEY4Lz8ePH6+233/Ybu/baazVkyBDNnTs3KDAHAABxKKNAGjPbP7V9zBwqtAMAkp5jgvOePXvqa1/7mt9Yjx49dPrppweNAwCAOFa0QMqZ6E5lP32Qf2BeX2U8DgBAgnNMcA4AABKIUT/zsvkBK+qz3YE8AABJwNHB+csvv2z3FAAAQCSYVXHPmcgKOgAgKTimWjsAAHC4+iqpZqVx27TtZcbPMRsHACDBOHrlHAAAOAQp6wAAhMTKOQAAiC6zlHXfFfTBRcbPNRsHACDBEJwDAIDoOrij7XFPizVftFgDACQR0toBAEB0nT7I2nioFmsAACQ4Vs4BAED0DS72fxy4Ku4pFidJuVMJzAEASYeVcwAAED2BheAGF0uFt/kH3xSLAwCAlXMAABAlRoXgtm9o+5zAYnEAACQBgnMAABAdVgrBmfUxN3suAAAJirR2AAAQHSEKwZVWutS3YqEK968I77kAACQognMAABAV737UpPrmERrfeat37NEvJ2rtqk/VY/8mretmEpjTQg0AkIQIzhNJfRXtZwAA8aFsvs7btFTndXY/3Ng8Qg9/OVlbWwZJ+45oUqe9xs8rnCeNuz128wQAIE6w5zxRlM2Xnhgvrb3R/WfZfLtnBABIVgZF3nxXzyVpd8tZhk99t+eFUZoUAADxjeA8EVDpFgAQT0yKuQ1M2avz+vTwPt7YPMLv+KNfTlTxc59r0fraaM4OAIC4RFp7IghVDZf0dgBArJkUc9vdcpZGDjhNNxx/RlM+f8477pfyLml5+S4VD+2rvKz0mEwXAIB4wMp5Img+Ht44AADRlFGg2uzr/IYe/XKitrYM0rhTXX6BuRSc8i5JL7+7L5ozBAAg7rByngg6dwlvHACAKMv50a9069Kh+nLfDu1uOUtbWwYpLzNNRWfWG54/MGWvd+UcAIBkRHCeCEL0kQUAwC5LZk9TaaVL3esO6fuZvVQyKsu0HkpggbiLz+sTiykCABA3SGtPBBkF0pjZ/mP0iAUAxIGSUVm6Z/Jwd2AuGX5mvXHWVX6r5jMKs9lvDgBIOiktLS0tdk8iVpqampSWlqbGxkalpqbaPZ3Io885AMApAj6zql0N2n3giAae0cMbmBuNAQDgNFbjUIJzAAAQdxatr9Xy8l3ex9MLszVvQo6NMwIAoH2sxqGktQMAgLBVuxq0Zku9ql0NUXlt38BccrdXi8b3AgAgXlAQDgCABNdWerhZSvnL7+7TR41fqG/aybr4vD7eY6ar2hZS1a3YfeCI6Tjp7QCAREVwDgBAAmsrPTzw+LjzeqvXKV20tvpDv9d5cOMOTS/MVvHQvoar2td+9pTOfHu5d+yNs67S93dP8P++w45Yqo0y8IweYY0DAJAICM4BAEhQpZUuw0C6c6cUNRw5pvQeXYOOv/TuftPXW16+S91OCt4RNyJlh19gLkkX7X1GI1IGe6uwp236pfTm860njJktFS0w/D55WemaXpjtNzcquAMAEh3BOQAACShwRdzXspd2RvR7DUzZazq+tWWQRqTs0IyTnvc/uGmplDPRdAV93oQcFQ/tS7V2AEDSIDgHACDBGBVUi5SLz+ujo1+e8Hv9vLyR0r+Dz93dcpYk8+BdB3eETG/Py0onKAcAJA2CcwAAEoxZQbWO8qSW52WlB69q9/qXezX8K2+cdZW27navmmelfGz8gqcPCvn9AgvK0fccAJDICM4BAEgwZoXTpuT31+oteyy9xsXnnqHczF6G1dolg1XtogXuNPWvCr5dlFGgN1fPDdqL7jVmTshV88C0/BGZadpa1+h9TN9zAECiITgHACDBmBVUazE6NzNNF2af7nfu5Lx+eqAkz/o39G2hljvVO2YYmBfOkwYXhQzMjdLyfQNzyV2cbuAZPVQyKsv6PAEAiGME5wAAJIDSSpdq6g4pN7OXSkZlBRVUk6RJj74e9Lz/mTjUOE3dqrL5funs3irs5fcan3/awJCBuWQ9LX/u6re1+8ARVtABAAmB4BwAAIe7bNlr3pXlFRV1erbCpXWzxuq9jw+rpu6QjjefUJfOwS3QJHcg7ElRD3sfd32Vf2AuuR+fPkjavsH4OW3sM5fC62fuaQ13a/EQy88BACAeEZwDAOBgpZWuoJTvrXWN+sbijapr+EKSO2Af3Mc44A0nEA5ycIfx+J7NhsP/aB6hg3v7qCQj9MsapeUH7jn3teylndq044DWzRpradoAAMQjgnMAABzGN4W9pu6Q4TmewNxj+74jKjz3DJW/d8A75qm+3m5mq+D9R0qbnwwafuTLyeq6ud4793PP7GmYSl/tatC5Z/bU4inD1KVzJ+/x0kqX5q5+2/Bbbq1rVGmliz3oAADHIjgHACCOBbYPC0xhz0w/2fJr9e/VXWtnjo5cO7KMAvcec78953Ok/KtU+68tytn1O+/wo19O1NaWQdL7Dap4v0ErKur8XmpSXj99Y3Bvvbp9v9ZWf+gdn16Yrcn57qX2klFZ2n3giGkP95q6QwTnAADHSmlpaTEq3pqQmpqalJaWpsbGRqWmpto9HQAAQgpsJxa48u2RmX6y30p54GOPxVOGRSd49a3W7lPs7dalT+jLfTu0u+Usd2DeTmtnjva7kbBkwzYte2ln0HmLpwwzXY0HAMAuVuNQVs4BAIhDRu3EjAJzSfrG4N7eFHdPtXbfFXbJ3TItaqvKGQWGFdiXzJ6m0kqXutcdUrf9n+rN3Q3tenlP0TqPW4uHaNOOA0H/fbsPHPFLe6cXOgDASQjOE5XJKgYAwBlefnef5XM9Ablv8L1u1tig9mp28MyrtNLV7uDcqGhd4H/fuWf2DGoVRy90AICTEJwnIrOeswAAxzvtlC765LPj3sehVsQDA/aIC+NGcMmoLD1bEVxZvi2hitb5/vet2VJveA690AEATkFwnmjMes7mTGQFHQAc5OLz+ujBjcGtyj757LgKzz1D/Xt1t3VF3PBGcM7EkMG60Wr37gNHgorATc7rp7GDe4e1bzxUS7jl5btUPLQve9ABAHGNgnCJpmaltPbG4PFJj0u5U2M/HwBAuwUWhPMVWCQtpuqrpCfGhz4nzKytwKr07RHq3+uBK3K9Vd8BAIglq3FopxjOCbFg1nPWbBwAELfmTcjRT8cbv3/vPnAkxrPxcTB4RT/IpqXuIN6ivKx0Tc7P6NANh3kTcrR4yjDDY6FW1gEAiAcE54nG03M2UO3zMZ8KACA8pZUu3bHmLZVWurxjF5/Xx/BcW4NNqzd8rQTxEVYyKkvTC7P9xnz3rRv9GwMAEA9Ia09EZumG0zay7xwA4lRg67MRmWlaN2uspOB07RmF2Zprd4GzwD3nRmz83DFKkw/1bwwAQLTQ5zyZma1UHNxBcA4Acai0MriK+da6RpVWunTumT117pk9tXjKMHXp3KlDe7IjKmeidNLJ7r+nZbgztLZvaD0+Zo6tnzl5Wel+/06h/o1ptQYAiAcE54mo+Xh44wAAW9XUHTIcf+r191W797D38fTC7PgoahZq1XxwsVR4W9zdDDb7N15XvUfnntkzPm54AACSGnvOE1HnLuGNAwBsUe1q0Jot9Urv0dXwuG9gLrlbglW7GmIxNXNGLTt9+a6ex5HczF6G42/s+kSTHn1di9bXxnZCAAAEYOU8EVGxHQDiXuA+8t49u2r/4WPex1mndZfrk8+Dnrf7wBF7V3mtFHmLw21UJaOy9GxFcGq7x/LyXep2UiddfF4fVtEBALZg5TwRGVVsH1QUdxdKAJCsql0NQf249x8+plnjztGVF2Rq8ZRhenBqnuFzbW8JZuVGb5zeDF43a6wWTxmmi7JPMzz+4MYdrKIDAGxDcJ6oihZIvYe0Pt5RJv3mEvvmAwDwMutRfk7vU3XP5OEqGZWlvKz0kC3BbGPWstPD5kJwbSkZlaXbLh0S8py42D4AAEg6pLUnqi3PSPu3+Y/t2ewez7/KnjkBACRJO/d/aml83oQcFQ/tG9QSzHZFC9zV2g/uaF0l9/w9jgNzD8+Nj8DsBV/3vrBNl+X1p5I7ACBmCM4T1XsvmI8TnAOArRqOHLM8HtgSzFb1Vf5BuG8g7oCg3JfnxsfL7+7TgxuD99G/sesTvbHrEz1b4aIXOgAgJgjOE1V34/10puMAgKgqrXSppu6QcjN7KTezl1ZU1AWdY1ZRPC4Etk8bM9u9gu5gnhsfR788YbqKTi90AECspLS0tLTYPYlYaWpqUlpamhobG5Wammr3dKKrvkp6Ynzw+LSNjlvdAACnu2zZa35VwkdkpkmS31heZprWxusKbRJ8plS7GnTvC9v0xq5Pgo5dlH2abrt0SPxkMAAAHMVqHEpBuERlVLAnzov0AEAiKq0Mbt+1ta5R378gS4unDPNWZ4/bwFwyb59mpa2aQ+RlpeuyvP6Gx+iFDgCIBdLaE1lgwR4CcwCIuZq6Q6bjnsrscW/ni8bjcdoyrb2s9EIvHtqXFXQAQFSwcp7oMgqk3KkE5gBgE7N95HG9v9xXfZX0Vmnw+PDE/Gxpqxe6WRs8AAA6iuAcAIAoKK106Y41b0lq3WPukZeZ5owVc8k8df2ccbGdRwyF6oV+vPmE1myppw86ACDiSGtPFoHtbwAAUeNbAG5FRZ1GZKZp8ZRh3mrtjgnMJfPU9QRLaQ9k1At9RGaa5q5+2/t4emG25k3IsWN6AIAERHCeDBKw/Q0AxCvzAnDSPZOH2zSrDvAUGPX7HEmOAqOeXui7DxzR8eYTfoG5xB50AEBkkdae6Oqr/C+oJPfj+io7ZgMACW9j7ceG42aF4RyhaIG7bdqkx91/Ft1l94xiJi8rXZPzM9Sls/El070vbFNppSvGswIAJCKC80Rntlew/N7YzgMAksCi9bX6+zv7DI85pgCcmSQvMDrwjB6G42/s+kRzV7+ty5a9FuMZAQASDcF5ojPbE7h9A6vnABBBpZUuv/3JvhxVAA6GPHvQzWyta2QFHQDQIQTniS6jQBpcbHzMbFUdABCWRetrg/Yje5QUZGjtrLExnhGiYd6EHK2dOdq0zZqjty4AAGxHcJ4MCm8zHk/wSrsAEAvVrgbTFXNJmnoBK+aJJC8rXZfl9Tc81nyihRZrAIB2IzhPBp5Ku76SpNIuAETby+8a7zGXpBmF2VTyTkAlo7KCetdLUmlVvSY9+rqu/t2bNswKAOB0KS0tLS12TyJWmpqalJaWpsbGRqWmpto9ndij1zkARNzc52pUWlUfNF5SkKHF38u1YUaIldJKlzbWfmxYBHBwnx4qu/ni2E8KABB3rMahrJwnkySvtAsAkbZofa1hYC6Rzp4MSkZl6dKvnWV4bPu+IxSIAwCEheA8WdVXSTUrqdgOAO0Uaq+549PZ+YywzKzFmkSBOABAeE6yewKwQdl8adPS1sdjZktFC+yaDQA4ktle85+OH6Q5RefFeDYRxGdEWPKy0lV47hkqf+9A0DHH97YHAMQUK+fJpr7K/6JLcj9mdQQALFu0vlYPbjRuR3nxeX1iPJsI4jOiXZ6+7kIN7uO/gk5vewBAuFg5TzZmvc0P7mAvOgBYkNDp7HxGtFvZzRertNKlmrpDys3sRWAOAAgbwXmyMettTs9zALBk94EjhuOOT2eXpObj4Y3DT8moLIJyAEC7kdaebOh5DgAdYlYAzNHp7B6du4Q3DkuWbNim7//6DS3ZsM3uqQAA4hgr58moaIGUM9Gdpth83H3RVV9FgA4AIfimLE8vzPZLbXd8OrsH2VURN+qXZdp/+Jgk6Y1dn2hVVZ0qf15k86wAAPGI4DxZZRRItc9TkRcALLhs2WvaWtcoSVpRUacRmWlaO3O0dh84ooFn9EiMwFxqza7y+2wgu6q9lmzY5g3MPfYfPqafrdqq+68YYc+kAABxi+A8WZlV5M2ZyEUYAPgorXR5A3OPrXWNeu/jw4m5v9g3u+r0QXwmdMCWDxoMx1dv2aPePbtp3oScGM8IABDP2HOerEJV5AUAeNXUHQprPCFkFEi5UwnMOyj/bPOMiuXlu1TtMg7eAQDJieA8WZntH6QiLwD4yc3sFda4Y9VXSTUr6WkeQbcWD1Hvnl1Nj5tV/gcAJCeC82RlVLVdkv58k1Q2P+bTAYB4VTIqSyMy0/zG8jLTEiul/Q9TpCfGS2tvdP/J50DEVP68SFPy+xseM6v8DwBITiktLS0tdk8iVpqampSWlqbGxkalpqbaPZ34sOUZd0AeaNpG0hkBwIdvtfaECsyXXSjtN2jxxedARC1aXxtU4X8ue84BIClYjUMpCJfszHrXHtzBRRkA+CgZlZVYQbnkvkFrFJhLfA5E2LwJOSoe2jfxKvwDACKG4DzZ0dMWAJLXns3mx/gciLi8rPSgoDxURkbCZmsAAAwRnCc7etoCgJ9qV0PyrG72HyltfjJ4fFARnwMxcNmy17xt+lZU1OnZCpfWzRrb5jEAQGIiOAc9bQHgK4H7gqcXZid2L+r8q9zBue8Keu8c6YfP2TenJFFa6fIG3x5b6xpVWuny/t3oGCvoAJC4CM7hllFAUA4gqVW7GvwCc8ndi7p4aN/EXkG//kX33vM9m90r6flX2T2jpFBTdyiscc8xgnMASFyOaaW2cOFCjRo1Sj179lSfPn102WWX6d1337V7WgCABPGTZ6sNx5OiF3X+VdLEpQTmMZSb2ctwvPlEi9J7GPdGN3sOACAxOCY4Ly8v16xZs/TPf/5TZWVlOn78uP7jP/5DR44kwUVTrNVXSTUr3X8CQBIorXSpruFzw2P0okY0lIzK0ojMtKDx0qp6LXtpp3r39A/Q8zLTWDUHgATnmLT2F154we/xU089pT59+mjz5s365je/adOsElDZ/IDicLPde9IBIIGZpRLnnNUzcVPa66uoNWKzdbPGqrTSpY21H+vv7+zzO7b/8DHNGneOGo4co1o7ACQJxwTngRob3YVSTjvtNNNzjh49qqNHj3ofNzU1RX1ejlZf5R+YS+7HORO5cAOQ0HIze2lFRV3Q+DWjB8R+MrHAjdi4UTIqS106dwoKziXpnN6nanJxhg2zAgDYwTFp7b5OnDih2bNna8yYMfra175met7ChQuVlpbm/crMzIzhLB3o4I7wxgEgQRilGCdsGrHZjVi2MtnGbOsEWyoAILk4MjifNWuW/vWvf2nlypUhz7v99tvV2Njo/aqrC14VgY/TB4U3DgAOUu1q0Jot9ap2NRgeXzdrrBZPGaYrL8jU4inDtDZRe0pzIzbu5GWla3phtt/YjMLsxN1SAQAw5Li09ptuukl/+ctf9MorrygjI3SqV7du3dStW7cYzSwBZBS4Uxv9Uh3nkNIOwPHmlFZrbfWH3see/uWllS7V1B3y7un1fCU0bsTGpXkTclQ8tK92HziigWf0IDAHgCSU0tLS0mL3JKxoaWnRf//3f2vt2rV6+eWXNXjw4LBfo6mpSWlpaWpsbFRqamoUZhl7gReWEUGRIAAJJDAw9xjcp4e272vt+DEiM03rEnW1PFDQnvM5UtFdds0GAICEZjUOdUxwPnPmTK1YsUL/7//9P5133nne8bS0NHXv3t3SayRacH7Zste0ta7R+zipLiwBwIJqV4MmPfq65fMXTxmW+CvnHtyIdaSo3JQHAESV1TjUMXvOH3vsMTU2Nuriiy/WWWed5f0qLS21e2q2KK10+QXmkrS1rlFLNmyzaUYAEH92HzjS9kk+zFqqJaSMAil3KoG5g1y27DXNXf22VlTUae7qt3XZstfsnhIAIIIcs+fcIQv8UVftatDL7+7TxtqPDY8ve2mnmk+0aN6EnMh8Q1ZWADiYWbXr/Mw0bQm4wSm5W6oB8cjspnxppYsVdABIEI4JzpNdtatBD23crpfe3d/mucvLd6l4aN+OF5MJ3JM46FvSsMsJ1AE4gif9t/DcM1T+3gHv+OS8fnqgJC9oa1DCtk6DIwWmr5tlddTUHeLnFgASBMG5AyxaX6vl5bvCes7uA0c6Fpwb9cHd8Q/3l+Su6l60oP2vDwBRFBh4D+7TQzMuHuRXBXvdrLHs30Vc8v35XVFRp2crXPr+BVlaURHcEpZsDwBIHI7Zc56sql0NYQfmknkqp2Vt9bvdtFTa8kzHvgcARIFR+u/2fUd0vPlE0E3LklFZumfycAJzxA2z9HXJXfjVF9keAJBYWDmPc1aKGU3K6+fXJmhGYXbHU9qt9Lv9803uIJ4VdABxhPRfE9QQcYRQP79kewBAYiM4j2PVrgZ9cDB0cD6jMFtzJ+ToRxcN0O4DR/xSNjsko0AaXiK91UY1/E1LpZyJXOgBiBu5mb1I/w0U1Nd8NjdW41RbP7+egNwTxBOgA0DicEyf80hwUp/zUPvMR57dS2MHnaGLz+sTmUA8lD9Mad1nbmbS4+52PAAQJ4yKva2dNdbGGdmovkp6Ynzw+LSN3FiNU4E/v+f26aHpX9VMWPD8v/2OjchM07pk/dkGAIewGoeych6HSitdhoH5T8cPik1A7lE23z8wzxgl1VcGn2clBR4AYoj0Xx9mNUQO7iA4j1O+P797Dn2u8vcO6OZVNYbn0k4NABIHBeHizKL1tZq7+m3DY2efHqGUdSuMqrXXV7pT3X2NmcPFHYC4RLG3r5jdQOXGalwrGZWlywsy/doAmjHbpw4AcBZWzuNIW5XZrVZgr3Y1dHz/udlKyzmXSBfcQFEhAHAKoxoi3Fh1BCtFYSUpvUdXrdlSH7m6MwAAWxCcx5FQH8JWK7AH7lWfXpiteRNywp9MqJWWjAIu6gDAKcrm+wfmw0ukortsmw6ss3JTvk/Prlr20k7v43Z/7gMAbEdaexwx+xBePGWY5lr4oDVaeV9evkvVrobwJ5NR4K7m64uVFgBxrtrVoDVb6tv3vpeIjLYovVXqHkfcy8tK1/TCbL+xGYXZWjxlmK68IFOzxp2jfYeP+R1v9+c+AMB2rJzHEc+HsG+APaMw2/J+SbOV990HjrQvza1ogbtNGinsABwgYplDiYRicI43b0KOiof2DdquVjIqS2u21Bs+p92f+wAAWxGcxxmzD2ErzFbere5VN0QKOwAHMMscKh7a1/s+mpTV2ykGlxDystINrwei8rkPALANae1xKC8rXZPzM9oMzAPTN83S37h7DiDRhcocktx9o+euflsrKuo0d/XbumzZa7Gcnn3YopTQ+NwHgMTCyrlDmaVvdmTlHQCcKtQKYmmlS1vrGv3Gk6o3NFuUEprR535EurYAAGKO4NyB2krf9E1/i9gHdH2V8YWd2TgAxJBZzY68rHT9qarO8Dk1dYeSIziX2KKU4Hw/96m9AADORXDuQFYLv0XsA7psvn+13zGz3SsxZuMAYAOzzKHczF5aUREcoOdm9orxDIHoslJ7AQAQv9hz7kBm6ZsfHDzi3X8esbZqRm14Ni2VtjxjPE57HgA2MqrZUTIqSyMy0/zPy0xLnlVzJI22ai8AAOIbK+cOZJS+KUkPbtyhBzfu0PTCbJ17Zk/D54bdXsWsDc+ezebnkzoJIM6smzU2Oau1I6lQvR0AnI2Vc4eaNyFHa2eO1k/HB7fDWV6+S8ebTxg+L+wPaLN2O/1Hhnc+AERRYPcKo/GSUVm6Z/JwAnMkLKq3A4CzsXLuYHlZ6aapal06dzItjhTW6pGnDY/f3vI5Uv5V7lXywHFWzQHE2JzSaq2t/tD72FNfg8JYSEZUbwcA50ppaWlpsXsSsdLU1KS0tDQ1NjYqNTXV7ulERLWrQZMefT1ofO3M0YYfyJcte82vpdCIzDStmzW27W/kW5VdkraXuf9My5A6d6FaOwBbBAbmHiUFGSqtqg8a97w3AsmCm1QAYD+rcShp7Q7XVgqbb3GkUL1+25RRIOVOlWqfl54YL5Uvcn/9+SZpXy2BOYCYq3Y1GAbmkgwDcylJCmPVV0k1KynQicgVhwUAxARp7QnArH1QoJq6Q6bjlvZgGlVul9xjORMJ0AHEVHsC7YQvjEWLS/iw2noVABAfWDlPEEbtgwKZ9fRN79HV2jcxq9ze1jEAiAKzwpdmEr4wllnrS1bQkxbV2wHAWQjOk4hRr19JWvbSTi1aX9v2C4SqxE6VdgAxtGh9reauftvSuT8dP0hrZ47W3ETfZ2t2k5Sbp0mL6u0A4CyktSeZdbPGasmGbVr20k6/8eXlu1Q8tG/oD2yjyu0SVdoBxJTRPlpJWjxlmHYfOBLUpWJO0XmxnJ59dr5oPM7N06RmdesbAMB+BOdJ6JzepxqOW9qDVrTAvb/cU619cJE7MPet5k6gDiCKQrWQTNpApL5Keqs0eHz4VN6Tobys9OT5XQAAByM4T0Id3oOWUeB/sUcBIgAx1NZ7WNIEIr43RcvvNT7nnHGxnRMAAGg39pwnoYjuQaMAEYAYYx+t3DdFnxgvrb3R/ef2DcbnkdKONlS7GrRmSz3t1QAgDrBynqQilvoZqgARqZQAoiRp09cl87aWgQYX8z6MkBatr/Wr0TC9MFvzEr1wIgDEMYLzJFBa6VJN3SHlZvby62cekdRPs1UZVmsARFnSpK8Hslp9vfC26M4DjmZUWNFScVgAQNQQnCe4y5a9pq11jZKkFRV1erbCpXWzxoZ8jlkwb8iogjvV2wEgeqzc/OR9GG0wK6z48IvbVTy0r/XrAABAxKS0tLS02D2JWGlqalJaWpoaGxuVmppq93SirrTSZdgHePGUYaYftr7BvCSNyExrM5iXRLV2AIgFz3vtzhf9q7OPmSPlfJv3YVhW7WrQpEdfb/O8EZlpmj9xaHJuIQGACLEah7JynsBq6g6ZjhsF56WVLr/AXJK21jWqtNJlbQWdi0EAiJ7AzhjDS6RzLmldSScwRxjystI17rzeeund/SHP21rX6BfEsy8dAKKHau0JLDezV1jja7bUhzUeUn2VVLOSqu0AIiLpK0obFYF7q9QdjNc+71+5vWy+LVOE8/xk/OCwn7O8fFfy/h4CQJQRnCewklFZGpGZ5jeWl5lmugputsEh7I0Pa27gQhFAxCxaX6tJj76um1fVaNKjr2vR+lq7pxR7ZkXgtpfRzhLtZtSW0Aqz/eoAgI4hrT3BrZs11nKBtykjM1TxfvDd8CkjM6x/wzU3+O+DlNwXijkTSbUEEDYqSn8l3A4YtLOERYFtCRc8/++gLW6BBp7RI0azA4Dkwsp5EigZlaV7Jg9vc994uCvtQeqrggNzD6utfwDAh9kKXdKt3Hk6Y/gaM0caXGR8Pu0sEYa8rHRNzs9QXla61s0aq8VThunKCzK1eMqwoJX1GV89TuptJgAQJaycw084K+1BQgXgXCgCaAezFbqkXLkrWuDOQgos/EY7S0RYyagsv89/35X1Df/+iAJxABAltFJD5NRXufeYBxo+VZr8eOznAyAhLFpf65faPqMwW3OTLRhoq10l7SwRA2bt19bOHJ1c20wAIEy0UkNEVLsarPc29aRd+q7gDCqSzhnnvnDkghFAOwTuiU26ICCwhdqY2e5VdF+0s0QMvPzuPtPxpPu9BIAoIDiHqcDVKkupa75plztfdO9B31HmPmZ0QQkAFuRlpSfnxb9RCzWKbAIAkJAoCAdDZhWSLRV/yShwp1YaVW2nvQ8AC5K+r7lH+b3G4xTZRBSVVrp0x5q3VFrp8hu/+Lw+huebjQMAwsPKOQyFqpBsafUqVE9e9kUCCKFdWTuJqL5K2r7B+BhFNhElly17zdtKbUVFnZ6tcGndrLGSWvuiB9aASMqsFgCIAoJzGOpwhWSzC8fyRa1/J80dQAD6mvswu8k5uJibm4iK0kpXUI/zrXWNKq10eau3J30NCACIItLaYchzd9xXWHfHjXryBiLNHUAA+pr7MLvJWXhbbOeBpFFTd8jSuG9fdABA5LByDlMdvjvuWxzuk93+q+YeB3ewAgTAi77mPow6YNDDHFGUm9lLKyrqDMcBANFHn3NYFlZbtUCmPdBLpMm/jswEASQE+poHMOthTm9zRIHvnnNJystM09qv9pwDANrHahwadnDeuXNn7d27V336+FfmPHjwoPr06aPm5ub2zTgGCM7bLyIFmtbcEFzBXZKmbeTCEoCfDt0MTAZWep8D7VRa6VJN3SHlZvby7jUHALSf1Tg07D3nZrH80aNH1bVr13BfDg7QobZqvs65xHjcrFUQgKTFntYQzHqfU8MDEVIyKkv3TB5OYA4AMWZ5z/lDDz0kSUpJSdETTzyhU0891XusublZr7zyioYMGRL5GSKqlmzYpi0fNCj/7HTdWmz8/6/DbdU8zIobbd/gvqhk9RwAWpmlrZtVcaeGB6KALBYAiB3LwfmvfvUrSe6V8+XLl6tz587eY127dtWAAQO0fPnyyM8QUTPql2Xaf/iYJOmNXZ9oVVWdKn9eFHRexAo0ZRS4WwAZ9e3lohIAWoVKWze70Unvc0RYRLa0AQAss5zWvnv3bu3evVuFhYWqqanxPt69e7feffddbdiwQRdeeGE054oIWrJhmzcw99h/+JiWbNgWdG6H26r5MmsBxEUlALi1lbZu1KqSKu6IsIhtaQMAWBZ2K7WXXnrJ+3fP/vOUlJTIzQgxseUD4w9Xs/EOt1XzoDUQAIRmJW3dt1Ul1doRBRHb0gYAsKxdfc5///vfa8mSJdq+fbsk6dxzz9Wtt96qq666KqKTQ/Tkn52uN3Z9YjhuJi8rPTIfyFxUAoA5K2nrtFFDlJltXTvefEJrttR7j7MfHQAiJ+zg/IEHHtCdd96pm266SWPGjJEkvfbaa5o+fboOHDigOXPmRHySiLxbi4doVVWdX2p7n55dTYvCRVxGAReUAGCkrQwj2qghBjxb2nxT20dkpmnu6rcNz59emK3OnVLaLDILADAXdp/zgQMHasGCBfrRj37kN/7000/rrrvu0u7duyM6wUiiz3kwK9Xao4rVHwAwZvT+WF8lPTE++NxpG3kPRVR4qrUfbz5hGpgb6d2zq2GRWQBIRlbj0LBXzvfu3avRo0cHjY8ePVp79+4N9+VgM1vvbLP6AwDmjDKMaKOGGPNsaftV2bthPc9TZJYVdACwznK1do9BgwZp1apVQeOlpaUaPHhwRCaFBFNfJdWsbK007BkLVY0YABCMNmpwELMiswAAY2GvnC9YsEAlJSV65ZVXvHvON23apI0bNxoG7UhyZqvjrP4AQPjoeAGbXHxeHz240eSz20SoIrMAgGBhB+dTpkzRm2++qV/96ldat26dJCknJ0cVFRXKy8uL9PzgZGar4zkTWf0BgFDM6nHUV0l9cqTvPCJ17kK9DsSMUYG4yXn9NHZwbw08o4dueKbKviKzAJAgwi4I52QUhIuxmpXS2huDxyc9LuVONVhVnyMV3RWr2QFAfDLLOKJOB+KAp0CcUfu0wCKzoc4FgGRiNQ61FJw3NTVZ/sbxHPQSnFsXkSruVqoKU60dSCpcrLfB7H3zO49If74peJwq7YhTi9bX+q2yTy/M1rwJOTbOCADsE9Fq7b169VJKSkrIc1paWpSSkqLm5ubwZoq4M+qXZd7UtDd2faJVVXXta4ditDdSkmqfb72YpN85kDS4WLfArB7Hns3m5/MeijhT7Wrw+12XpOXlu1Q8tC835QAgBEvB+UsvvRTteSBOLNmwzW/PmGTcDuVnq7aqpu6QcjN76f4rRpi/YM5E833nXFACSYOLdYvM6m70HyltftL6+YCNdh84YjrO7zsAmLMUnBcWFkZ7HogTZm1PfMdz7lyvz4+fkCTt2H9Ef3t7r2rvnmD8glRlByAu1i0zq8Zu9F5KlXbEqYFn9AhrHADgFna1dklqaGjQb3/7W9XW1kqSzj//fF177bU67bTTIjo5xF7+2el6Y9cnhuOSe8XcE5h7fH78hH62aqvxCnq4VdnZgw4kJC7Ww1C0wJ1d5HkvlIz3oed8O7bzAiwyq+zuuUnHDTkAMNYp3Ce88sorGjBggB566CE1NDSooaFBDz30kAYOHKhXXnklGnNEDN1aPES9e3b1G/Nth1JTd8jweWbj3lUgX2arPWXz3Rega290/1k2P7zJA4hbnot1XzMKs7lIN5NR4O5qkVEgbS8zPsdsHIgD8ybkaO3M0XrgilxNyuunNdUf6uZVNZr06OtatL7W7ukBQFwKe+V81qxZKikp0WOPPabOnTtLkpqbmzVz5kzNmjVLb7/9dsQnidiq/HmRabX23Mxe2rE/OD01N7OX+QsGrgIZBeaheqKzgg4khHkTclQ8tC/V2oEk4fkdv3lVjd849SYAwFjYwfmOHTv03HPPeQNzSercubNuvvlm/f73v4/o5GAfs/Zp918xQn97e69fanv3Lp1CF4WT2q7Kzt50ICnkZaVzQR6uwUVS+SLjcSDOUW8CAKwLO609Pz/fu9fcV21trXJzcyMyKcS32rsnaEp+fw3q3UNT8vubF4MzUl8l1ax0/+kr3L3pAJAswtkeBMQZs7oSHxw8omqXcRFaAEhWKS0tLS3hPKG0tFS33Xab/vu//1tf//rXJUn//Oc/tWzZMi1atEg5Oa09a4cPHx7Z2XaQ1ebviJKy+QEViGe7U95Nj8+Riu6KzdwAIN5RMBMOtWh9bVArRY+8zDStnTU2xjMCgNiyGoeGHZx36hR6sT0lJUUtLS1KSUlRc3NzOC8ddQTnNqqvMq42PG2j/0UmF58Akh3vg0hA1a4GvfzuPj24MXgbW6/uJ2nr/GIbZgUAsWE1Dg17z/nu3bs7NDEkKat7ytvamw4AiaytDCPAofKy0k33nx/6/Est2bDNtN4NACSLsIPzs88+OxrzQKJjTzkAhEbXCiQ4s/3nkrTlA/afA0DYBeGAdqGgEQCEFirDCEgAeVnpystMMzyWfzaV2wGA4ByxU7TAvcd80uPSdx6R+gwJrtrua8sz0vOz3X8CQKIzyyTa+WJs5wFE0dpZY9Wru3/iZp+eXUlpBwC1oyCck1EQLk5Y2VP5m0ukPZtbH/cfKV3PBSrgBEs2bNOWDxqUf3Y6F9xWeYrAvf0nacc/go8HFs8EHC7c9wneVwA4WdSqtTsZwXlsVLsatPvAEQ08o4fysgLS1KxUbd/yjPTnm4LP+c4jUv5VkZ8wgIgZ9csy7T98zPu4d8+uqvx5kY0zcoDAG5ZGJj0u5U6NyXSAeMP7CgCnsxqHWk5rr6ioCNka7ejRo1q1alV4s0TCWbS+VpMefV03r6rRpEdf16L1tf4nWNlT6bti7stsHEBcWLJhm98FtCTtP3xMSzZss2lGDmBUBM4IxTORpHhfAZBMLAfnF110kQ4ePOh9nJqaql27dnkfHzp0SN///vcjOzs4SrWrQcvLd/mNLS/fpWqXTwVWK1Xb+480PsdsHEBcMKu2TBXmEKwUe6N4JpJItatBa7bUe68deF8BkEwst1ILzH43yoZPogx5GDDrX7r7wJHW9HZP1XbflaLhU1svUDMK3Knrm58M2HNeQEo7EOfyz07XG7s+MRyHiebjxuPfuEU6Y7D7xiWBOZLEovW1fjf5pxdm874CIKmE3ec8lJSUlEi+HBzGrH9p0HjRAnff3oM73FWI31rp/pJai8Nd/6J77/meze4VcwJzIO7dWjxEq6rq/FJQqcLchs5djMfPGMwecyQVs+y7tTNH874CIGlENDhHcsvLStf0wmy/D9cZhdnBReGk1pWgtTf6j29a6g7cPSvoBOWAo1T+vIiqyuGwstUHSAKhsu94XwGQLMIKzt955x199NFHktwp7Nu2bdOnn34qSTpw4EDkZ2dg2bJlWrJkiT766CPl5ubq4Ycf1gUXXBCT7422zZuQo+Khfc2rtfsKVRyONE7AsbhwDoPRVh/2mCMJtZV9x/sKgGRguZVap06dlJKSYriv3DOekpISsqJ7R5WWlupHP/qRli9frgsvvFBLly7Vn/70J7377rvq06dPm8+nlZo9TFurWWmr5jnv4A72XgJIXLzPAUF7zmcUZmvuhBwbZwQAkRHxPucffPCBpW989tlnW5thO1x44YUaNWqUHnnkEUnSiRMnlJmZqf/+7//WvHnz2nw+wXnsGRV3mef7QRvY33f4VGny4+bHPXvSAQBAwjG9oQ8ADmY1DrWc1h7NoNuKY8eOafPmzbr99tu9Y506ddK3vvUtvfHGG4bPOXr0qI4ePep93NTUFPV5opVZcZfioX1bP3CLFkiH90pvlbofv7VS6tnXPW7U/9d3TzoAAEgoeVnpBOUAkpbl4Nzlclk6Lysrq92TCeXAgQNqbm7WmWee6Td+5plnatu2bYbPWbhwoRYsYJXVLpZaq9VXtQbmHp4AnD3pQNxjlQsAACAyLAfnAwYMMGyV5tlrLrn3nn/55ZeRm10H3X777br55pu9j5uampSZmWnjjJKLpdZqoQJwqhgDca3NbSsAAACwzHJwXl1dbTje0tKilStX6qGHHtKpp54asYkFOuOMM9S5c2d9/PHHfuMff/yx+vbta/icbt26qVu3blGbE0Kz1FotVABuVMVYkmqfZ+UcsJmlbSsAAACwrJPVE3Nzc4O+9u/fr2nTpunRRx/Vbbfdpp07d0Ztol27dtXIkSO1ceNG79iJEye0ceNGXXTRRVH7vuiYeRNytHbmaD1wRa7WzhwdXHXVE4D78m0jlDMx+EU3LXWnwwOwTahtKwAAAAhfWH3OPbZs2aK5c+fq1Vdf1bRp0/S3v/3NUiuzjrr55pt19dVXq6CgQBdccIGWLl2qI0eO6Nprr43690b7tVncpWhB6x7zwDZC7DsH4pKlbSswR+s0oMNKK12qqTuk3MxeKhkVnZpHABBLYQXnO3fu1B133KHVq1friiuu0DvvvKPs7OxozS1ISUmJ9u/fr//5n//RRx99pBEjRuiFF14IKhKH+PazVVu9H6b3XzHCPZhRYHyByr5zIO54isBNyuuntdUfeseDtq3AGC0igQ67bNlr2lrXKElaUVGnZytcWjdrrM2zAoCOsdznfObMmfrtb3+rcePGadGiRRoxYkSUpxZ59Dm3X86d6/X58RPex927dFLt3RNCPynoQnaOVHRXVOYHILTAInCT8vrpG4N7U63dqvoq6YnxwePTNrKCDphYsmGbtnzQoPyz0/WtnDO1ssKl0qr6oPMWTxnGCjqAuGQ1DrUcnHfq1Eknn3yyhgwZEvK8LVu2hDfTGCI4t9fPVm3V6i17gsan5PdvXUE3QwooYLtqV4MmPfp60PjamaMJzK2qWSmtvTF4fNLjUu7U2M8HiHOjflmm/YePWTr3ygsydc/k4VGeEQCEz2ocajmtff78+RGZGJJXTd2hsMb9mKW9A4iZUEXgCM4tYqsOYNmSDdssB+aSlJvZK3qTARATyV5LguAcMZOb2Us79gdf3PNhCjjDq9v3G45TBC4MRi0ifTtUAPDa8kGD5XMz00/23uxPxgt6IBEUPfCytu9zxwrJWkvCcis1M+Xl5frb3/6mhgbrb6BITvdfMULdu/j/yHXv0qntlHYAtqt2NfgVf/OYnNePVfNwFS1w7zGf9Lj7T2poAIbyz277veU/zu+jzPSTVdfwhVZU1Gnu6rd12bLXYjA7AJE0adlr3sDcY2tdo0orXTbNyB6Wg/PFixfrzjvv9D5uaWnRpZdeqnHjxunb3/62cnJy9O9//zsqk0TiqL17gqbk99eg3j00Jb9/28XgANii2tWgNVvqVe1y33g1S2kfO7h3LKeVODIK3HvMWTEHTN1aPES9e3Y1PT6jMFvjc85UXcMXfuPJeEEPONmc0mpVf9V9IZCl7a8JxHJae2lpqebOnet9/Nxzz+mVV17Rq6++qpycHP3oRz/SggULtGrVqqhMFImDlXIgvgVWZJ9emK3ioX0NzyWlHUA0Vf68KKha++4DR7wdIu5Y85bh82rqDpHeDjiAWWaeR7Jtf7UcnO/evVvDh7dWwPzb3/6m733vexozZowk6Re/+IUuv/zyyM8QycmoOjsV24Goq3Y1+AXmkrS8fJc+bvoi6Fz6mgOIhVuL/TsF+b7v5Gb20oqKuqDnpPfoqjVb6mnzCMQ5s8w8STq3T4+ku8lmOTj/8ssv1a1bN+/jN954Q7Nnz/Y+7tevnw4cOBDRySE5BFVlDOprPtv9Z+BY0YLYTRJIcNWuBu0+cEQfHDT+kDS6q/0fJqvpABArJaOy9GyFS1t9UmL79OyqZS/t9D6eXpiteRNy7JgeABOe647jzScMj+dnpmlNkhWDk8IIzs855xy98sorys7Olsvl0nvvvadvfvOb3uP19fU6/fTTozJJJK7Llr3m/UBdUVGnqk1/15JDS/1P2rQ06HnatFTKmcgKOhABgWnsVtFCDUA8WDdrrPdGf3oP/8Bccmf/FA/ty/sVECcCrztGZKb53WCbnNdPD5Tk2TE121kOzmfNmqWbbrpJr776qv75z3/qoosu0vnnn+89/uKLLyovLzn/EdE+pZX+d7olqf/+TVIXiy9wcAfBOdBBRmnsVrHfHEC8KBmVpZJRWVqzpd7wODcTgfhgdN2xta5Ri6cMU5fOnZJ+K4rl4Pz6669X586d9fzzz+ub3/xmUN/zDz/8UNddd13EJ4jEZVR9sSWcFzh9UKSmAiStUHu9QmG/OYB4ZHbTkJuJgP1+tmqrXt2+3/BYl86dNDk/I8Yzij+Wg3NJuu6660wD8EcffTQiE0LyMCriUn5ihOZoTdtPHk4LIiASzC5YJ+X189tnPqMwW/8xtK9flWQAiDd5WemaXpjttzLHzUTAXtWuBl2x/HUdN95eLokbaB4pLS0tYS1W+vqv//ovPfHEEzrrrLMiOaeoaWpqUlpamhobG5Wammr3dCD/PeeSlJeZprXnlhnvMw9EUTggIgL3fs0ozNbcCTneYi0E4x1Epwkg5nj/AuKDlbo2nuuORGY1Du1QcN6zZ0/V1NQoOzu7vS8RUwTn8SmoWrskvbRQKl/U9pOnbeRiF4gALmSjxKj7BDcVAQBJoLTSpbmr3zY93qdnVz1+VUFSXHdYjUPDSmsHosFTxMWjtNKlg3sGaKaVJ1MUDoiIvKz0pPhwjKn6quAsIDpNAACSgJUV828M7s21R4AOBednn322unSxWlobaFtrmnuqUk6aqBknPR/6CRSFA9rFMGMFkXVwh/k4wTkAtGL7T0Kx0gmme5dOuv+KEbGZkIOEHZy7XC5lZmYqJSVF//rXv7zjLS0tqqurU1YWF3lon8DWaou//L42NI/SvAtO0tdHXSjVPh+QHjqHN3CgHXxrPayoqNOzFS6tmzXW5lklILObh9xUBIBWbP9JCL43/bt07mR6Xq/uXTQ+pw+BuYmwg/OBAwdq79696tOnj9/4J598ooEDB6q5uTlik0NyMWqttrVlkP7ckqmvZwx3B+I5E7mzCnRA4E0wyd1ftLTSZbiCzl70DsgocF9kclMRAIyx/SchBN70H9zHuPL64inDyNZrQ9jBeUtLi1JSUoLGP/30U5188skRmRSSk1FrNc+4V0YBb9ZABxjdBPOMB35gBu4Xm16YrXkJXk014ooWcFMRcDDPDcrjzSfUpXMnblRGmtn2n/J7pR+siu1cEPaWt9JKl55+/X29s/ew3/j2fUdUeO4ZKn/vgHdsRmE2gbkFloPzm2++WZKUkpKiO++8U6eccor3WHNzs958802NGDEi4hNE8igZlaVnK1xBrdX4RQYix9JNMBnvF1tevkvFQ/tyYRoubioCcc0sQ8isoBU3KiPIbJvP9g3uVXXeO2Mm3C1vge2QA/Xv1V1rZ44m+y5MloPz6upqSe6V87fffltdu3b1Huvatatyc3N1yy23RH6GSCrrZo21fteO4iFA2KzeBNt94Ijh83cfOMIHLICEYZYhFKqgFTcqIyijQBpc7A7GA1E8M2oCr7XD3fJmdH6g3MxedIJpB8vB+UsvvSRJuvbaa/Xggw/SJxxRE9hazRDFQ4CweVaH5k8cqvc+PhzyJtjAM4z3i5mNA4DThMoQMrtB6bH7wBH94Z8feN9HKW7VAYW3GQfnO1+UcqfGfj4JynMN8NjLO7R9n/vn27NCfv5ZxnFd4JY3z2tsrP045Pci87X9wt5z/uSTT0ZjHoB1FA8Bwma0OnTP5OGm5+dlpWt6Ybbfc2YUZnMHHEDCCJUh1NaNyNtXv6WjzS2SpB37j+hvb+9V7d0TIj7HpPZWqXTBDVzbRUConuNb6xp1Tu9TDY/5bnmz0rdckmaNO0e3Fg9p1zwhmde5B+JVqN7BAIKYrQ5VuxpCPm/ehBytnTlaD1yRq7UzR2sueywBJBCzAPyFf+3Vex8f1vTCbMPj5555qjcw9/j8+An9bNXWSE8xOYS6fuParsOs9BzvdlInjchM8xvzXf228hqS+yY+gXnHhL1yDtiO3sFAWDqyf5z9YgASlVGGkCT9/Z19+vs7+zQiM81b0Mq3Wvutf6oxfD2zbhhoQ6jrN67tOuzld/e1eU5uZi/dM3m43170c8/sqTVb6jXwjB6m1xElBRlq+OyY0k/pqqkXZHG9EAEE53AeegcDYWH/OAAYmzchR8VD+2plhUulVfV+x7bWNeq9jw8H7Z3NzeylHfuDg5XArhewyOi6TuLaLgKspKL7rpB76j4tWl+ruavf9p4zKa+f4XMJyCOP4BzORO9gwDL2jwOAubysdP2pKrjFpBRcEEuS7r9ihP729l59fvyEd6x7l04UhesIz3Xd9jL348FFXNt1UGmlyzQwv/jcM9SvV3fDorBGKexrqz/UpLx+Wlv9oXeM64joIDiHc9E7GLDMszpEv1EACJab2UsrKoIDdLPV8Nq7J+hnq7ZSrT2SuK6LmFAr5j8dP0hzis4zfa5ZCvs3BvfWjy4awHVElBGcw3GWbNimLR80KP/sdIpOAGFoa/84v1sAklXJqCw9W+Hfu7mtdlAE5IhHbRVvu/i8PiGfH2orHHVooo/gHI4y6pdl2n/4mCTpjV2faFVVnSp/XmTzrADn43cLQLJbN2usX0Es+jTDicxWviVrqehshbMXwTkcY8mGbd7gwWP/4WNasmEbq3xAB/C7BQBunoJYknsFMtwUXoL7CKmvoq5QO5mtfC+eMszyzyRb4exDcA7H2PKBcU9ms3EA1vC7BQD+AvfsTi/M1rwJOSGfc9my17xp8Ssq6vRshUvrZo2N6jwTUtn8gI48s90F42CJ2cp3uDeLSGG3Rye7JwBYlX+28RuE2TgAa/jdAoBWRnt2l5fvUrXL/IZlaaX/fnXJ3YqttNIVlTkmrPqq4JZqm5a6x2HZvAk5WjtztB64IldrZ47W3DZuLCF+EJzDMW4tHqLePbv6jfXp2ZW0W6CD+N0CgFZme3ZD7eWtqTsU1jhMHNwR3jhM5WWla3J+BqvfDkNaOxyl8udFVJQGwmB1zyS/WwDgFqpatZlwW7HBxOmDwhtHxFE3wV4pLS0tLXZPIlaampqUlpamxsZGpaam2j0dRAhvIoCx9uyZBAAEv3/OKMxuMzXYd8+55G7FtpY95+EL3HM+uFgqvI3CcDEQ+DM8IjONugkRYjUOJTiHo/EmAhirdjVo0qOvB42vnTmaFDcAsIBq7Taqr5LK75W2b2gdozBcVJVWujR39dtB4+FUeYc5q3Eoe87hWBRfAcy1Z88kAKBVe/bslozK0j2ThxPMRIJvYC5RGC7KqJsQHwjO4Vi8iQDm2rNnEgCAuEBhuLCUVrp0x5q32r1AVe1qUPMJ42Rq6ibEFsE5HMvszeLolyc69AYFJAJPn1NfMwqz9d7Hh/n9iLT6KqlmJSs6ABApzcfDG09ily17TXNXv60VFXWau/ptXbbstbCev2h9rSY9+rpKq+qDjuVlppEFEmNUa4djlYzK0rMV/qnt3bt00uotezQiZYc+r9qrqk2DtGT2NBtnCdhn3oQcFQ/t690zueD5f+uxrwocraio07MVLmo0dFRg4SL2RAIJib3kMda5S3jjSSrUFk8rP6fVrga/woce/3F+H43POZOfdRsQnMPR1s0a6/3APPrlCa3eskdzT3pWM0563n3CIan29/9Wzo9+Zes8ATv4FjN67+PDHfoAh4H6Kv/AXHI/zplIVWEggfgWn+XGZozQUi0kz7Xvzv2fGh5fvbne0s0kszo0l37tLE3Oz4jIXBEegnM4XsmoLJWMytIda97SiJQdrYH5V3J2/U6q/wEXy0gqgW2ABpx+iuF5G2s/Jjhvr1B7Inm/ARJCR1cm0U4ZBe5MJL/MpDm8tyq4U5GRivcbVPF+Q5s3k6hPE38IzpEwcjN76fOqvcYHuVhGEjFKU3v/4GeG56af0jUWU0pMrOwACS9U8dn2BOekx4ehaIE7E+ngDvf7agJfx1n9uTC6WdSWwJtJgS0Cpxdm+10zzCjMpuWqjQjOkTBKRmWpatMg6ZDBQS6WkUTCaZc29QIuDtuNlR0g4eVm9tKKijrD8XCRHt8OGQUJ/55q9nOxZMM2bfmgQflnp+vW4iGSzG8WXTAgXYP6nKqd+z/Vm7sbgo57biZd/bs3Vf7eAe/49MLsoPo0BOb2IjhHQlkye5p7j/mu37UOcrGMJGO2B21SXj+trf7Q+5i74xGQRCs7QDIyKj4bqoK12Qoo6fERUF+VcO+1Zj8XX5v/gj492ixJemPXJ1pVVafKnxeZ3iyaMjJDJaOyVFrpMgzOczN7qeiBl7V9n//N++Xlu1Q8tK/ystK5HogTBOdIODk/+pV7j3mCvYEDVpjtRZtRmK25E3L0o4sGcHc80pJgZQdIZr7FZ0OlHYdaGY90enzSSdDOGGY/F57A3GP/4WNasmGbbi0eEvJmkdnNJElBgbnH7gNHuB6IIwTnSDjuD9Cuys0crZIMPvCQPMz2os0ad443JY674wAQPk/xWTNtrYybrXim9+iqNVvquWEaSoJ1xvDd8232c2FkywfuFfG2bhYZHb9jzVumr0vxt/hCcI6Ewn4uJDOzO/ANR47FdiLJIAHTKwG0X1sr40Yrmn16dtWyl3Z6H3v2/yJAAnXGCOykMr0wWyMy0/x+Ls7s2VUfHw7+3M4/u/XmTVs3iwKPm90EuPjcM7gpFGc62T0BIFJC3bUGkoFZgaL2FC5CCGXzpSfGS2tvdP9ZNt/uGQGIsdJKl+5Y85b3GsPK+++6WWO1eMowXXlBpmaNO0f7AgKw5eW7VO0K3i+c9BKkM4ZRJ5Xl5bs0f+JQ78/F4inD9ObPi9S7p38nlT49u3oz4NqjZFSWRnyV3u5xbp8eeuq6C9v9mogOVs6RMNjPhWQXbuEitEOCpVcCCF9glt4Tr+7SjIsHaXCfHn77eo3efz0rmmu21Bu+tqfbBrVBfDi8M4Ynjf2Dg+Z7vgNXuit/XmRYrb0jrNZOgL0IzpEwzFJ2xp3q0j/XvqotR07T6eeN4c0ICY0P3yhLoPRKAOEzytLbvu+Ibl5VI0kqPPcM9e/Vvc33X7N9vq9u3+99LYlUd68OdMb42aqt3s/E+68YEb05GghMYzdi9rMQiYA8UFvp8LBfSktLS4vdk4iVpqYmpaWlqbGxUampqXZPB1EQWKn6gfQ1mvz5c97Hj305URvOms4+dADts+YG6a3S4PFpGwnOgSRwx5q32izgtXbmaEsr3oGB2+S8flrj0+4y3NdLGluekfZslvqPlPKvCnlqzp3r9fnxE97H3bt0Uu3dE6I9Q0nuFfNJj74e8hxPJ5XA55E5kXisxqGsnCOh+K4ajjvVpaLXn/M7PuOk57WhfpRKK7lzCCBM9VXGgfnwqQTmQJKwUl3bamuqeRNyVDy0rzcQ233giGFwTqsrH7+5xB2YS9LmJ91f178YdFq1q0H3/K3WLzCXpM+Pn9DPVm2NyQq6Z4tCoJ+OH6SzT++hgWf00HsfH9Yda97yZloYFYwjcyK5EJwj4XhTdl76q+HxizttVU3dOIJzAOExS2k/Z1xs5wHANka1PQKF05rKSntL39dL6m1LnhVzX3s2u8d9VtDbSiU3q1EUSUs2bNP6t/caHuvXq7sm52cY1i4I7EW+vHyXiof25eZMEiE4R9JpEdWrkRhIfYuxBKkYDKBjfLP09hz6XOXvHfAem1GY3e7347ysdE0vzPYLLH1fL+nbxQYG5r7jXwXnRhXRA0X7GnDUL8u036AVmkeXzp1MaxcYIXMiuRCcI3ENLpLKFwUN7+09RnOS7W4zEg6pbzZweMVgAJHjW1grkjdKA1PdPa9n1i527nM1mnpBVnIEb/1HutPYjca/YpZK7tG9S6eopbRXuxq07MXtIQNzyZ0J8aeq0FsjAs9H8iA4R+IyuJB+J/vH+v7FU7RmSz2rjXAss16ppL7FQAcqBgNITFZS0zv6emap2KVV9SqtqldO3566ZsyAxE51z7/KHZz7rqD3L/BLaTcLZPv3Ollfzz49aoG5larskjQiM015Wel67+PDhrULCs89I2KZGHAmgnMktoAL6T+/3UPLfSpnstoIJzJbGSD1LUYyCgjKAcRUW4Xoaj86rLmr39YTr+7S2aedoo+avlDheX2i0o7LVte/GLJau9nWgMCK6JFkJZXeY2tdo6pdDYa1C/Iy0/T0dReyZS3J0UoNScOspQUtSuA0/CzbpL6KFXMAtglsF2tFz26d9fsfX5h0nw2xDHDXbKn3603flgeuyNXk/AxJSV7gL8nQSg0IwGojEkVbRYMQIb7BeO3zAXvNZ7szcwAgRjyF6DbWfqy/v7PP0nMOH23WpEdf17jzeusn4wcnzedEpLcahGKWSp99xinadeCzkOf71i4AJFbOkURYbUSiIfUtisrm+wfjRqZtZAUdgC2s7nEOlIjb+UorXTr47ibl9/hEXx91oS3vy4H/Pzyp9GbjSD5W41CCcyQV3iQBtKm+SnpifNvnTXpcyp0a/fkAgIFqV4N+urJark8+D+t5ibQocdmy11S8d7lmnPR866BBZlM4N7Pbe+Pb7HncSIdEWjtgyKxFCQB4Hdxh7Tz6mwOwUV5Wul657RLTnutmEmU7X2mlS4P3rNOMrs/7H9i01F0M+KsVdCutRz0B9Kvb92tt9YchzzVjlkofyxR7OB/BOZJOXqedyuu8Q+o0SFIBxTgA+LMSdNPfHECcCOy5vuzF7dpa16gDR4z7bSdK3+y+FQu1pOsK44MHd0gZBZZaj4baIkCbUsQawTmSS8A+0tXdv6e5DZMlSSsq6vRshUvrZo21aXKAsSUbtmnLBw3KPzs98drixKOKX4c+/p1Hgtr3AEA8yMtK1xPXXCDJHag//OJ2vbhtv/e4k4uH+i2mnLVPhftNAnPJe5O1rWLAVtqgJUqmAZyB4BzJo74qqMDTlM+f0zMpw7W1xf0mvrWuUaWVLp17Zk9S3xEXRizYoEOffylJemPXJ1pVVafKnxfZPKsEtuYG6a1S8+Nj5hCYA3CEvKx0/e6aCxJiz7NvG7kVFXXa23uzZpudPHyqN7PJLEvAM76ywtXm906UTAM4A8E5ksf2MsPhwk5btbW5NY31qU3vq/ajw97HiVjZFM4wadlr3sDcY//hY1qyYRsr6NFQX2UemI+8Vsr7IansABzH6XueSytdQf3dXz6QptndTJ7w1kqpZ1+paEGbrUcbPjNO/Tc6F4gFgnMkvZSAx76BucR+I9ij2tWg6oCLEY8tHzTEeDZJIlQhOAJzAGiTJ/V8b+MX+uJ4c0S2Y9XUHQoa29oySOW9rzRPbfcpCheqGPD4nDMNe8aXFGRo6gVZXPsh5gjOkTwGF0nli4KGXz4xwvv3vj276qPDwXdRX353H2/QiCmzfXKSlH82P4tRYVYIzidFEgBgzDf13MOzHeuW/zhPNXWHlN6jq87pfap27v9UDUeOGRbjDUzDz83spRUVdUHf76MLbpfO+rFU/Qdp85PBE/qqKJxknj1QMipLz1b4r8znZaZp8fdy2/NPAHQYwTmSR0aBu/el777zMXP0/V6TdP5XBUY+PPS5HtxosY0SEEVme9zSu59ESnu0GL1HDJ8qTX7crhkBgCMYpZ577D98THNXv214LLAYb2Dl9MJzz1D/Xt2VmX6y6hq+8I7nZaZ9FdR/FdgbBecW212umzWWzj2IGyktLS0tdk8iVqw2f0eCq69y3009fVDQali1q0GTHn096CmLpwxTl86dHF1MBc4TeJGSn5mmNXQTiD6j94gQ7xsAkOzuWPOW4eq2VYunDNO5Z/Y0vAbzyEw/Wd8Y3Ds4gK6vksrvlbZvaB0bM0cquqvd8wEizWocyso5kk9GgenFtVHhkBGZaX53fKcXZqtzpxRaWyEqfNP5Qu2TQxQFvkcEtGDUmNlS0YJYzwoA4pZZ6rlVNXWH1KVzp5Dn1DV8ERyYB74/Z14oFd/DTVQ4FivngAFPgHS8+YRpKpZH755daW2FiAhcKadTQByor5KeGB88Pm0jF38A4MNoz7lVVlbOJenKCzJ1z+Th7gdm78/DS6TJv27XPIBosRqHhr5FBSSpvKx0Tc7PaPMurtTa2groiGpXg19gLrk7BVS7qMxuK7MK7qEquwNAElo3a6wWTxmmKy/I1Ljzeuui7NM0a9w5GpGZFvJ5nv3jnuzFUHIze7U+MHsffqvUHbgDDkRaOxCCWVGuQLS2QkeZVWfffeAI6ex2MisoZLHQEAAkk5JRWUEF1W4tbm2x1la1dt/tXI+9vEPb97V+NrYWgftKqPdhn0rtgJMQnAMhGO1BN0JrK3SU2Y0gqzeIECUmXR646AMA64yCdjOetmeT8zMMq6i31mY5R3nDS9wr5YG4gQqHYs85ECCwv2bg2A3PVGm/Ty/0Pj27qoI954iAwD3nMwqzNZc95/GBau0AYLvAz8lx5/XWfSc9qtN3rm09iUrtiENW41CCc8CH1YJcSzZso1o7Isb35o8kqrMDABDArN2tJC0Y+ZmuPreZG6iIW7RSA8JkVpCreGjfoCCJgByRcvXv3lT5ewe8j6nQDgBAMLPaLJI0f/MpGn7haOVlcFMbzka1duAroQpyAdFQ9MDLfoG5RIV2W9RXSTUrjav7hjoGAIiZtmqwcL2GRMDKOfAVCnIhlkorXX5VaH1RoT2GyuYHFHubLRUtcP99zQ3+hYZ8jwEAYqqtIr2+12tGheQAJyA4B75i9KY/ozCbIAlRUVN3yPQYN4RipL7KPzCX3I9zJkoVvw6uAOw5xn5GALCFp9Xawy9u14vb9nvHfa/XLlv2mrbWNUqSVlTU6dkKl87pfao3WL//ihF2TB2whOAc8OHbXzPcglzcpUU4cjN7aUVFXdD4xeeewQ2hWDm4w3h8e5lxax7PcwjOAcA2eVnp+t01Fxh21ymtdHkDc4/Be9ZpxN6d6nTiHP1p/zj97e29qr17gh1TB9pEcA54fNUqKe/0QcrLD+/i2+gu7bpZY6MxSySIklFZerbC/yLi3D499NR1F9o4qyTTnj649M4FgLjg6YfuKzArbU3XO5Xfaack6Qd6Ud8/8aImH7tbP1u1lRV0xCWCc0AK3nc66FvSD1dLMu577svoLu3WukaVVrpYQUdI62aNJePCThkF7n3kvr/7w6eanz98KqvmABDHfLPSLu/0kjcw98jvtFOXd3pJ1XXftmN6QJscEZy///77uvvuu/Xiiy/qo48+Ur9+/fTDH/5QP//5z9W1a1e7pwenM9p3uuMf0rILtSj7qTb7npvtHa6pO0SwhTaVjMri58RORQvc+8gP7pB2vii9tdL4vOFTpcmPx3ZuAICw+Galje+0xfCcEZ126kRmr9hODLDIEcH5tm3bdOLECT3++OMaNGiQ/vWvf+n666/XkSNHdN9999k9PTid2b7T/dt0cM9vJY3zDhn1PTfbO5zLGz8CLNmwTVs+aFD+2em6tXiI3dOBh2c1fO2NwccK50mDi1gxBwCHWDdrrGp/P0c5uzYbHn8nZRAp7YhbjgjOL730Ul166aXex9nZ2Xr33Xf12GOPEZyj40LsIR3Raaf+dGKc31hgmyujvcN5mWmshsLPqF+Waf/hY5KkN3Z9olVVdar8eZHNs4KX2U260wYSmAOAk9RXKWfX7wwPvX9yjn45b0mMJwRY54jg3EhjY6NOO+20kOccPXpUR48e9T5uamqK9rTgRBkF7j3mO/4RdGjriXOCxozaXLF3GKEs2bDNG5h77D98TEs2bGMFPV6Y3aSjABwAOIvZzda8H2nAdx+O7VyAMHWyewLtsWPHDj388MO68UaDFEQfCxcuVFpamvcrMzMzRjOE4/xwtdQ7OEiafPYXfo9D9T0vGZWleyYPJzBHkC0fNIQ1Dht4isP5GjOHVXMAcJrm48bjmRfEdh5AO9ganM+bN08pKSkhv7Zt2+b3nD179ujSSy/V5Zdfruuvvz7k699+++1qbGz0ftXVBe8LBry+uyxo6KK9z2jD97rrgStytXbmaM0NKAYHWJF/tvENHbNx2KRogTRtozTpcfefRXfZPSMAQLg6dzEer30+tvMA2sHWtPaf/exnuuaaa0Kek52d7f37hx9+qHHjxmn06NH69a9/3ebrd+vWTd26devoNJEsTNKgzjv8ps4bd0mMJ4NEcmvxEK2qqvNLbe/Tsysp7Xaqr3L/znvS1j1/zyhgtRwAnMxsO9L2De73ft7jEcdsDc579+6t3r17Wzp3z549GjdunEaOHKknn3xSnTo5MiMf8czszbx8kfTlF+5VNaCdKn9eRLX2eFE2P7h9oseY2fyuA4CTZRRIg4vdwXiggzsIzhHXUlpaWlrsnkRb9uzZo4svvlhnn322nn76aXXu3Nl7rG/fvpZfp6mpSWlpaWpsbFRqamo0pgqnC3XRPm2jlFFA4TfAyeqrpCfGhz7nq991AIBDmb3X0x4TNrEahzqiWntZWZl27NihHTt2KCMjw++YA+4twEmKFkgnnexeLQ90cIcu+39feFumraio07MVLiq1A05iVsU38Bwu3ADAuTxFPgMXXMoXub/IkkKccsTKeaSwcg5LTO62lo3+o65/MSVoPDP9ZNU1tFZ1H5GZpnWzxkZ1igDaiZVzAEge9VXS9jLjRRfe6xFDVuNQNm4DgUxaKr30qfGKuG9gLklb6xpVWunyGyutdOmONW8FjQOIMaPfb1+0TwOAxBHq/Xx7WezmAVjkiLR2IOaKFkg5E/0qOOdWurSiwlo7vpq6Q9709suWvWaYCg/AJoG/35J/tXYAAAAbsHIOmMkokHKnei/WS0ZlaURmmt8pmeknGz41N7OXJPeKuScw9zBaWQcQYxkF7mDcswfd53cdAJBABheFNw7YiJVzIAxGxd98V8YlKS8zzbtqXlN3yPB1fFfWkRiqXQ3afeCIBp7RQ3lZ6XZPB20J7MxAcSAASExGxeHYwoQ4RUE4IALMqrWXVro0d/XbQecvnjKM4DyBLFpfq+Xlu7yPpxdma96EHBtnBFMUBwKA5FRfxRYm2MZqHEpwDkSZ0cr61AuyaL2WIKpdDZr06OtB42tnjmYFPd4ErpYHmvS4O70dAAAgghKqzzkQV8K88xqYCv9sRetqOgXinO+nK6sNx3cfOEJwHk/qq0IH5lJrcTgAAAAbUBAOCEfZfHeP5LU3uv8sm2/paSWjsnTP5OGSRIE4B6p2NWjNlnpVuxr8xksrXXJ98rnhcwae0SMWU4NVnsJvZth/CAAAbMbKOWCV0crbpqXulkwWL+opEOcMvpkOuw8cMd1Pbvb/M6dvT1bN443ZqnjhPHfFXgJzAABgM1bOAavMVt7K77X8Ep4Wa1bHEXuXLXtNc1e/rRUVdZq7+m2/wFySlpfv8q6gm/1/u2bMgCjPEmHzVOv1NWaONO52AnMAABAXCM4Bq8xW3rZvcK+qW2DUK9239RrsZdSX3sjuA0ck8f/TMeqrpJqV7iyXaRvdhd+mbZSK7rJ7ZgAAAF6ktQNWZRRIg4vdwXig8nulH6yy9DJGvdIRH8zS1AP57ifn/2eco585AABwCFqpAVaF6o8s0SM5AZj1pfc1Oa+fxg7urYFn9GBfebyrr3IXbgzE7yoAwIP+54gBWqkBkdRWf2TJ/cYegTf1n63a6l2Fvf+KER1+PVhXMipLz1a4gvrS/8/Eodp94Ihe3b5fa6o/1JrqDyX5F4dDHApVJ8JipgsAIIGRXYU4Q3AOtMVKf2QpIj2Sc+5cr8+Pn5Ak7dh/RH97e69q757Q4deFdaHS1G9eVeN37vLyXSoe2pcV9HjVVp0IVkgAIHlFoAsPEGkUhAPa0lZ/ZCkiPZJ/tmqrNzD3+Pz4Cf1s1dYOvS5CK6106Y41b/n1mvf0pfcNzD1F4AKZjSMOeOpEGLHyew0ASFxmnwN8PsBGrJwDbTFbffvOI1LnLhHboxSqBzqi47Jlr3lT2FdU1OnZCpfWzRpreK5vETgr44gThbcZF3GMQKYLAMDBzD4H+HyAjVg5B9pi1h85/yopd2rEUp/ogR5bRm3TttY1+q2g+8rLStf0wmy/sRmF2aS0x7uMAqn/SP+x/gWkLAJAsjO7vuPzATZi5RywomiBew9SFKt53n/FCP3t7b1+qe3du3TS/VeMoFVXFITKVDD7N543IUfFQ/tq94EjVGt3ivoqac9m/7E9Vew5BwDE5PoOCAfBOWBVRvRX22rvnhBUrT2c1GtYl5vZSysq6gzHQ8nLSicod5JQewq5CAMAxOD6DrCK4BywKkZ9MH3bp4VKvWYFvWPM2qbx75pg2FMIAAAcguAcsMKmPphmqdcbaz9Wl86dSK3uoFBt03yxrcDBPHsK/X5/2VMIAADiT0pLS0uL3ZOIlaamJqWlpamxsVGpqal2TwdOUV8lPTE+eHzaxqhf4JdWujR39dshz5lemK15E3KiOo9EUO1qaNdecd9tBZI0IjONbQVOFKPMFwCAw/F5gSiwGoeycg60xcY9q0ap14GWl+9S8dC+rKCHsGh9rZaX7/I+tnpDg20FDhZ4ccWeQgBAW2zKlAQ8aKUGtMXKntX6KqlmpfvPCFs3a6wWTxmmKy/IVElBhuE5uw8cifj3TRTVrga/wFxy39CodjW0+Vx6zzvUmhvc2S5rb3T/WTbf7hkBAOJdfZV/YC65H0fh2g4wQ3AOtMWoD6Yk1T7v/rNsftQDgZJRWbpn8nBNvcB4tXbgGT1U7WrQmi31loLOZGJ248LKDQ16zzvQmhukt0r9x7i4AgC0JVSmJBAjBOeAFTkTg8c2LZW2PBPTu6x5WemaXpjtNzajMFsb/v2RJj36um5eVaNJj76uRetro/L9nWjgGT3CGvdVMipLIzLT/Mao6B7H6quCA3MPLq4AAKHQ3QNxgD3ngBVmF/Z7NpufH6X9rfMm5Kh4aF9vcTNJmvTo637nsA+9leeGhm9q+4zCbMv/NlYruiMOhArAubgCAIRi1N1jcLFds0GSIjgHrDC7sO8/Utr8pPXzIyQvK90bXK7ZUm94zu4DRwjOvxJ4QyPcf5eSUVkE5U5g9ns3fCrF4AAAbSta4M6WLL9X2r6h9YvCcIgR0toBK4z2nY+ZI+VfZTwew0CgI2nbicpo/31eVrom52dwwyKRGf2eDp8qTX7clukAABxq+wb/x9QuQYywcg5Y5bmbGtj70mw8RtpK2w6nv/eSDdu05YMG5Z+drluLh0R13tHS3rZpgUhldyibfx8BAA5nYwtdIKWlpaXF7knEitXm74Al9VXS9jL33wcX2f6GbRSEhxOojvplmfYfPuZ93LtnV1X+vCi6k46waldD0P57SVo7c7QkWb5Jcdmy1/z6m4/ITNO6WWMjO1kAABB/6qvc3XcCTdto+7UenMtqHMrKOdAeZfP9C4aUL7J9P5LvPnTJvL+3UaG4JRu2+QXmkrT/8DEt2bAtLlfQzVa1X353n+H5d//lHW1xHfI+DnWTorTS5ReYS9LWukaVVrpYQQcAINEZFYaL8ZZFJC+CcyBc9VXB7dMk91jOxLh58w7V3zswON/ygXFvdLNxO/muaq+oqNOzFa42V7V9A3MpdDX7mrpDQWOecYJzAACSAFukYBMKwgHhCtWuaXuZVLMyLoqGhFMoLv9s4zRvs3G7hFrVlqSLz+tj+bV8b16UVrp0x5q3VFrpUm5mL8PzzcYRJ+qr4uZ3DwCQADIKpFy6fSC2WDkHwhWqTVr5ota/x0Gae6hCcYHF31ZV1fmltvfp2TXuUtrbWtU2+m+enNdPa6o/DHrOBwePqNrVoAXP/9tvJX5EZppGZKb53QTIy0xj1TyeBW4zoeUNAABwIArCAe0RGAyYiYPiIUaF4syKv8V7tfbSSpfmrn47aHzxlGF+wXPgf3NgYby2LJ4yTJKo1u4EFO4BANihvoq0d1hGQTggmjx7kTzV2iX/VXOPOGi7EVgozmnF33yVjMrSsxWuNle1Pf/Nnn7nxUP7qnhoX7387j49uDHEtoSv1NQd0j2ThxOUOwEtbwAAsbTlGenNx6WPfRYLyNhChBCcA+2VUdB68b/lGeNzmo/Hbj4WOan4m5F1s8a22YO82tWgh1/crhe37feOTS/M1rln9rT0Pdhf7iBm20xCbT8BAKA9fnOJtGdz8HicFQWGc1EQDoiEzl3CG7dROMXfPCvP1S77AnejOZSMyjJd2V60vlaTHn3dLzCX3BXajzefaPP7sb/cYTwtb3zR8gYAEGlbnjEOzD1CFQwGLGLlHIgEB63eWS3+FrhPO1Rv8GgJdw5Gvd19dencybBI3oAzerC/3CmM9vjR8gYAEG2hAnMpLq/54DwE50AkeFbv/CpGx+/qXVvF34yC3MDe4NWuBq2scKnhs2Man3NmRIJa3zl9K+dM0zn8o/Zjw7mb9Xb3GHhGD03Oz1Dx0L5BRfIIyh0gsBDj8BLpnEtaA/I4/X0DACSAxjrzY3F8zQdnoVo7EEkJUrlzzZZ63byqJmj8gStyNTk/w7D6+YjMNK2bNTYo6K92Nejld/dJcvchN2vlFlhBvme3zjp8tDloDoHjnkrzkvuGwaRHXzf8b5pRmK25MV75RwSZVWX3GF4iTf517OYDAEgeZp9BPc+SSv7g6Gs+xIbVOJTgHEAQsyB37czRkmQaAAcGzt27dNLnx/33eU8vzNbqLfV+gfgpXTrps+Nt7wc3M2vcOd4V9MAbB5cM6a3/vmSwX8V6OFDNSmntjaHPIUAHAESD2WfQpMel3Kmxnw8ch1ZqgN0cvIqel5VuuDc7Lytda7bUmz4vcKU7MDCXZLgn3Cww75d2sj5s/ML0sYdvpfl5E3IM09bhcFb28r1VKl1wg+N+3wAAcc5BtYXgbATnQDQE7o11UP9L3zZla2eODgpyB57RI2ZzmZTfX9/KOdM7h3/UfqxlL+0MOi+w0nxgb3ckAKO6Dkbobw4AiDSH1RaCc5HWDkSa2b6kaRvj/k38smWvaWtdo/exZx95IKM95316dtU+n1T1cAWmwPfp2VUVX+0l9xW4N93sPCQYTyZK83F3i8K3/yTt+EfweQ74PQMAOJSDsyJhL9LaAbuY9bmM8xW90kqXX2AuSVvrGlVa6QqqZO5JHQ+s1h4YOBvtOZ9RmK3nAvacewLsUBXkPdqqNI8EZJSJ8sPV0pob3Kns3nFWMQAAUURnEEQZK+dApDl05XzCg6+odu/hoPErL8jUPZOHW36d9lZrBwy19fvEKgYAIF5secbdD73/SCn/KrtngzjCyjlgFwfuS6p2NRgG5pKUm9krrNcKDLTN9n8TkMOStjJRWMUAAMSD31ziDswlafOT7q/rX7R3TnAcgnMgGooWSDkTHbOit/vAEcPxrNO6B6W0AzFFhVwAQLzzrJj72rPZPc4KOsLQye4JAAkro8Dd+zLOA3PJvAL7g1PzYjwTIIAnE8VXnGeiAAAS2JZnpOdnu//0CAzM2xoHTLByDiBkX3PAdg7LRAEAJCiz1PX+I91/D9R/ZGznB8cjOAcgqbUCe2BfcyAusLccAGCntlLXNz/pf7z3EFLaETbS2gF45WWla3J+BoE54l99lVSz0v0nAADR1lbq+vUvSoO+1Tq+f5u7FSgQBoJzAICzlM13t1dbe6P7Ty5+AADRZpai7hmvr5J2/MP/2Kal3ERGWAjOgVhitQ/omPoq/zaFEhc/AIDoy78qOEDvX9Cauh6q9SdgEXvOgVgpmx/Q+3y2u9AVAOva6nsOAEC0XP9i697z/iP995TT+hMRwMo5EAus9gGRwcUPAMBO+VdJE5cGF3uj9ScigJVzIBZY7QM6pr7K/fvSfFwaXCxt39B6jIsfAEA8oPUnOojgHIgFVvuA9gvcEuIxuFgqvI2LHwBA/KD1JzqAtHYgFkh1AtpnyzPGgbnkv3oOAADgcKycA7FCqhMQHrMVc19sDQEAAAmC4ByIJVKdAGuMiigaYWsIAMBOnpooLLwgAgjOAQDxp/zets9hawgAwE60yUWEEZwDAOJLfZX5fvJv3CKdMZgVCgCAvcza5OZM5PMJ7UZwDgCIL2atBwcXS+PvjO1cAAAwYvZZtb2M4BztRrV2wE71VVLNSvefANzM9pEX3hbbeQAAYMbss6p8kbTmhtjOBQmDlXPALuxTAozVPh88xv5yAEA88bTJNSpe+lap+8/Jv47ljJAAWDkH7GC2T4kVdCQ7syrtOd+O+VQAAAipaIFUOM/42FulXNchbATngB3M9imZjQPJYnuZ8Ti/GwCAeDS4yPwYn10IE8E5YAezfUr0bEYyK5vv3qtnhN8NAEA8yiiQhpcYH+OzC2EiOAfs4Nmn5Is9tUhmZunsEr8bAID4NvnXwQE6n11oBwrCAXYpWuDuhXlwBz2bAbPUv8J50rjbYzsXAADCNfnX0gU3mF/X1VdxzYc2EZwDdsoo4A0akMxT/0Lt5QMAIJ6YXdfRoQcWkdYOALAfWz0AAImIDj0IAyvnQLwg3QnJjq0eAIBEY9aFZHsZn3MIQnAOxAPSnQA3tnoAAJLNxrulujelzAul8XfaPRvYiLR2wG6kOwEAACQms9opnvH7zpVevU96/1X3n/edG7u5Ie4QnAN2M6tSbTYOAAAAZwhVU2Xj3dKnH/sf+/Rj9ziSEmntgN3MqlSbjQOJhFoLAIBEZ1ZTpe5N4/PNxpHwWDkH7EaVaiSrsvnSE+OltTe6/yybb/eMAACIjowCKXeq//Vd5oXG53Y9le2NSSqlpaWlxe5JxEpTU5PS0tLU2Nio1NRUu6cD+GMFEcmkvsodkAeatpGffwBA8rjv3ODUdg8KBCcMq3EoK+dAvDC6owokKmotAAAg3fKe9I1bpLNGBB+jQHDSITgHAMQetRYAAHAbf6f09RnGx7hpnVQIzoF4VF8l1azkbikSF7UWAABoxU1ryIHV2o8ePaoLL7xQNTU1qq6u1ogRI+yeEhBZZfP9+56z3wiJyqx6LQAAycZz09rvGpCb1snGccH5bbfdpn79+qmmpsbuqQCRV1/l/6YsuR/nTOTNGYkpo4CfbQAAJG5aw1lp7evXr9ff//533XfffXZPBYgOimQBAAAkL0+BYIktjknIMSvnH3/8sa6//nqtW7dOp5xyiqXnHD16VEePHvU+bmpqitb0gMhgvxEAAEByY4tj0nLEynlLS4uuueYaTZ8+XQUF1tM7Fi5cqLS0NO9XZmZmFGcJRABFsgAAAJKX2RZHVtCTgq3B+bx585SSkhLya9u2bXr44Yd1+PBh3X777WG9/u23367GxkbvV11dXZT+S4AIKlogTdsoTXrc/WfRXXbPCAAAALHAFsekltLS0tJi1zffv3+/Dh48GPKc7OxsXXHFFXr++eeVkpLiHW9ublbnzp31gx/8QE8//bSl79fU1KS0tDQ1NjYqNTW1Q3MHAAAAgHaprzIu/FZfJT0xPvj8aRvJpHQwq3GorcG5VS6Xy2+/+Icffqji4mI999xzuvDCC5WRkWHpdQjOAQAAANiqrT3lQcfnkEnpcFbjUEcUhMvKyvJ7fOqpp0qSzjnnHMuBOQAAAADYykrb3MCWapK7cjvt1RKeI4JzIOl5Up+aj0udu7S+UdMHEwAAwDlC7Sn3vZ7LKHB/Ubk9qTgyOB8wYIAckI0PREbgm7IR3qgBAADiXzhtc62ssiOhOKKVGpC0jN6UjdBiAwAAIP6F0zaXyu1Jx5Er50DSCOfNNzAdCgAAAPHHs6d8e5n78eAi4/PCWWVHQmDlHIhn4bz58kYNAADgDLXPS+WL3F9PjHdvYwwUzio7EgIr50A8yyiQhpdIb5WGPo83agAAAGcIZy95YOV2rvcSGsE5EO/OucQ4OC+cJ502kDdqAAAAJzHbtlh+r/SDVcHjnsrtSHiktQPxzixdfXCRlDvV/fealRSEQ/ypr+JnEwCAQGbXdts38JmZ5AjOgXgXar9R2Xz3PqW1N5rvVwLswM8mAADGMgqkwcXGx6jEntRIawecwGi/Eb0vEa/42QQAILTC29wr5YEo8JvUWDkHnCKjwJ3G7glu6H2JeFV+r/E4P5sAALhRiR0GWDkHnKS+qnX13OzO6s4XW/eiA7FWX2W8EiCxGgAAgK/AzMh9tdLzs6X+I6X8q+yeHWxAcA44Rdl8/1ThMbON26y9VSpdcAN3XmEPs9XxwcX8TAIAEMhTif03l0h7NrvHNj/p/rr+RXvnhpgjrR1wArM9vOkDjc8nfRh2MVsdL7wttvMAAMAptjzTGph77NnsHg887/nZweNIGATngBOEG2yTPgy7sIcOAIDwBAbmRuO/uUT6803uFfU/3+R+jIRDWjvgBKF6nX/5RUC6O4EQbGbUXQAAABjrP9IddBuNS6FX1tmbnlAIzgEn8KxGGgXhGQUEQog/np9NAAAQWv5V7uDcNwDvXyD1yZFqVkqvPWD8vD2bCc4TDME54BShViMJhAAAAJzr+hdbV8j7j3Rf7z0xPvRzPCvrSBgpLS0tLXZPIlaampqUlpamxsZGpaam2j0dAAAAAPBXX9V2YN5roDR7a0ymg46zGoeycg44jW+vc1bLAQAAEouVQsDfeyL680DMEZwDTmLU67xogV2zAQAAQKS11XWH4r8Ji+AccAqzXuc5E3mDhr3I5gAAIHKMCgEPnyqdM47P2gRHcA44hVmK08EdvEnDPmRzAAAQebQlTUoE54BTmKU4NR+P7TwAD7I5AACIHrrxJJ1Odk8AgEWeFKdAf77JvXoJxFqobA4AABB99VXuXuj1VXbPBBHAyjngJEUL3Cvof77Jf3zTUvd4/lW2TAtJyiybo61CNgAAoOPYWpZwWDkHnKZzF+NxVtARa0bZHFSQBQAg+sy2lrGC7misnANOE2pVkv2+iDUK1gAAEHsUCk5IrJwDTmO299xjexl7jxBbGQVS7lQuBgAAiBW2liUkgnPAiYoWSN95xPhY+SJp7Y3SE+NJcwcAAEhEbC1LSCktLS0tdk8iVpqampSWlqbGxkalpqbaPR2g4wILgRiZtpE3agAAgERUX+VOZW8+7q5LxBazuGQ1DmXPOeBkvvt9P9ntXjUPxN4jAACAxJRRINU+T9X2BEFaO+B0nv2+g4uMj3+y231XlT6YAAAAiYWq7QmFlXMgUXj2HgW+QZcvCl5R544qAACA81G1PaGwcg4kkqIF7j3mhfNCn8cdVQAAAOejantCITgHEk1GgXTawLbPM7vTCgAAAGegantCIa0dSERW7pZyRxUAAMD5fAsEU63d0Vg5BxKR0V1UX9xRBQAASByeAsFc3zkaK+dAogq8iyr5/71mJXdXAQAAgDhBcA4ksowC/+A7o0Aqm08vTAAAACDOkNYOJBN6YQIAAABxieAcSCZmFdq3l8V2HgAAAAD8kNYOJIP6Kndg3nzc+Hj5IunLL0hvBwAASCSea0DqDDkCwTmQ6AL3mPcfKe3ZHHzepqXuAnK8cQMAADgfdYYch7R2IJEZ7THfs1nK+5Hx+WZp7wAAAHAOszpDW56xYzawiOAcSGRmwXZqP+NxT5s1AAAAOJfZNeCfb3KvqCMuEZwDicws2B5c5E5t8jV8qvuNnMrtAAAAzhZqwYVOPXGL4BxIZBkFwUH4mDnu8aIF0rSN0qTHpeEl0lsrpbU3Sk+M544qAACAkxldA/qiU09coiAckOiKFrgLvRlV6vT8fe2N/s+hOBwAAICzFS2QPvtEqv693TOBRaycA8kgo8AdmBulrZvtSaI4HAAAgLONvNp4fHBRbOcBS1g5B5JBqFYaZnuSKA4HAADgbJ70dr/rwDlkR8aplJaWlha7JxErTU1NSktLU2Njo1JTU+2eDhAb9VXufeSBpm1sfWMOCt7nSEV3xWJ2AAAAiLb6qtYtjpLxdkdEjdU4lJVzINGFSlv3vCGH2pcOAAAAZ8socH+FyqaE7dhzDiQ6q2nrofalAwAAwNnqq/wDc4m2anGG4BxIdKHaqfkqm+9Of6edGgAAQOKhCHDcI60dSAZtpa2b3UmlnRoAAEBioAhw3GPlHEgWGQVS7lTjYJs7qQAAAInNajYlbMPKOQDupAIAACSDwGxKSapZSUHgOEFwDiQr35YaRj0w/3979x8cVXnvcfyTUAh2NJFqFMmmCJoBOi0Cu8JYtKAQUqfjHQvXkSmNQhXQBgeoHaC2Y6DXuVDoDEy1tlHvUEvrEB1LK9QWt8k03mvpbZNQIw7kJlYqCQJWSpLbGUOEc/84d5P9cc5mEzb77J7zfs1klj3nLDzsnJw9n32e5/tI0tH9XKgBAAC8hMrtWYth7YAfORV/m3ZX4nFU8AQAAPAeKrdnJcI54DduF+O2sPPxzDsHAADwFuoNZSXCOeA3bhfd7pPO25l3DgAA4C3UG8pKhHPAb9wuuod/Kl15few2KngCAAB4j1Pl9rIKI03BAMI54DdOF+OIc8ftx7IK6cE6qXxzhhoFAACAjCrfYt/vRUJ528GBWkQwgnAO+FH5FmneJvf9bQcz1xYAAACYE3/fR2E4YwjngF+VlSffT0EQAAAAb3O732vYntl2QBLhHPCvZMPbpYG56c17pP3r7EcAAAB4h1storaD9J4bQDgH/Cx+rlFEpBDcs3dIr6yRmnbbj8/eYaadAAAASL9AyL0QHKMoM+4TphsAwLBASFr2ov3t6Ift9jeogZDdU97ZFHtsZ5O9fValmbYCAAAgveZtcK43xLJqGUfPOQBbICTdtHRg6bT4YB7hth0AAAC5x2mq4/SldqcNQ9szip5zAM5KgvZwdqftAAAA8I7yLdK0u+xA/k691LLX/pHs4F6+xWjz/IKecwDOZlUmBvGSEEPaAQAAvCgQsoeyt9TGbmdptYyh5xyAu5X1A3PPS4IEcwAAAC9zKwLXFh6Y+ogRQzgHkNysythQHl84DgAAAN7gVgSuYZv08UcMbx9hDGsHkLpwtfTcAmnfavsxXG26RQAAAEgXp+JwEQxvH3GEcwCp6Wi0L8rRuEgDAAB4S/kWaeZ9zvvawplti88QzgGkxu1izEUaAADAWwonmG6BLxHOAQAAAAADysqTb+9olN7cywjKNCOcA0jNYBdpAAAAeIPT3PPpS+2iwL9YRQ2iEZJnWZZluhGZ0t3draKiInV1damwsNB0c4DcE66OnXc+d71UvtlUawAAADCSIqv0vFOfuP55tAfrWMUniVRzKEupAUhd+RZp2l0spQYAAOAHkXu9fauTH/dhO/eFaUA4BzA0gRAXXwAAAL/4sH3wY9zWR8eQMOccAAAAAOBssOA9d739SIG4S0bPOQAAAADAWSAklQSlzqaBbcVTpVvX28H96H67MFzE3HX2VEgMGT3nAAAAAABnHY2xwVySPjg20KMeXSw48pwe9GEhnAMAAAAAnLnNOf+wPfk+DBnD2gEAAAAAztzmnCebi06BuGGh5xwAvKSjkYIsAAAgfQIhex55tLnrB1bwcdp35qi0f53UvCdDjfSGPMuyLNONSNWvf/1rffe731VLS4vGjh2refPm6Ze//GXKr0918XcAyEnh6th5XxRkAQAA6dLRaA9Xv+rGxGV1o/f9ZkPsHPWSoLSyPrNtzTKp5tCc6Tl/+eWXVVlZqRUrVujNN9/UG2+8oa985SummwUA2aGjkYIsAABg5ARC0k1LE4N59L4zRxOLx3U20YOeopyYc/7xxx9r7dq12rFjhx544IH+7Z/5zGcMtgoAskiygixOH6IAAADpFh/Mo7fPqsxsW3JQTvScNzc3q7OzU/n5+Zo5c6auu+463XnnnTpy5EjS1/X29qq7uzvmBwA8aTjFWgAAAIbLqc5NSdD5WLftiJET4fyvf/2rJGnz5s36zne+owMHDmjcuHGaP3++zp496/q6rVu3qqioqP+ntLQ0U00GEEGBsswpq4h9HinWAgAAkE7haum5BdK+1fZjuNrePqsyMYgXT5VGjeZeMAVGC8Jt2rRJ3/ve95Iec/ToUTU3N2vZsmWqqanRqlWrJNm94oFAQE888YRWr17t+Nre3l719vb2P+/u7lZpaSkF4YBMoUBZZvxildRSO/C8rEKat4FgDgAA0q+j0Q7k8R6sG7j3aN5jD2XvOiG1/27gGJ/eC6ZaEM7onPNHH31Uy5cvT3rM5MmT9f7770uKnWNeUFCgyZMn67333nN9bUFBgQoKCtLSVgBD5FagbNpdhMZ0ig/mktR20A7nAAAA6ZZKnZtZldI10xJDPPeCSRkN58XFxSouLh70uGAwqIKCArW2turWW2+VJPX19en48eOaOHHiSDcTwHBQoGzkdTQmBvMI3mcAADAS3OrZvFNvV2yPcLsXbNguLXsx/e3ygJyYc15YWKiHHnpI1dXVeu2119Ta2qqHH35YknTPPfcYbh0AR24X7qP7WU4jXdw+9CQKwQEAgJERCEnT703c3lIbO6/c7V6k7SDzz13kRDiXpB07dmjp0qWqrKzUzTffrL/97W+qr6/XuHHjTDcNgJNAyJ5XFO/YAemVNdKzd9jPKRg3fG4fetNd1iAFAABIhxvucN4e3XEQCCUWq3U6Dv2MFoTLtFQn4gNIo45Gqel56fBPE/fduJAiIZcqvuje9KXS4hpjzQEAAD6QSlG4oRzncanm0JzpOQeQowIhKX+U877oYC7ZIZMe9KEp32J/wH25xn4kmAMAgJHmNELSaQnXVI+DJMMF4QD4RElQatqd2rEUMhu6QIj3DAAAZFb5Frvy+oft9lQ7t3uRVI8D4RxABsyqlF7/vnTu+ODHUshscB2NfMABAADzUu0giD+OexlHhHMAmfGv/+E85ygaw5wGFz/HnHn6AAAglyTUy7lXWvyMseZkE8I5gMyIzDmKvhhL9gX5hjv45jQVHY2J798bu+yhYrx3AAAg2zndy7TU2o8EdArCAcigaXclbmupJZinym3ZEZYjAQAAucDtniV+jXSfIpwDyBy3C3JbmLXOU+E2H595+gAAwLSOxsHv55Lds9DZwLB2ABnkdkFu2DbwZ+ZQu3OaGsA8fQAAYFqqNXECIXtKY2QoezQ6G5RnWZZluhGZkuri7wBGUPzF28mDdQROJ5HKphf6pFGjmQ4AAADM62h0Lvqb7H7uF6tiA/rc9VL55hFpXjZINYfScw4gs6LXujz7bmyveURbmNAZz+kb6ZuWmmoNAACALVlNHLf7ucXPSLNXsZxaHOacA8i8QMgOlmXlzvsbttnfqEZLZR6TV7lVaffjewEAALLLcGviRO4HCeb9COcAzDm6331fS+1AQA9X28Ol9q22H+ODu9c1bHfeTuEUAABgWqQmTrxk93lwRDgHYIZTb3C8llqpeY/zeph+CegdjVLbQed9FE4BAADZwGm5XEb5DRnhHIAZqfb6djY5b/fLephu71NZBcPAAABAdkg27zwVfp6+GIVwDsCMVHt9S4Lu+9rC6WlLNnN7n+ZtyGw7AAAA3Ljdr5x9d/DAHT99MVyd/vblCMI5ADOc5icVT419Pne9NKtSKp2TsWZlHaf3ibXNAQBANnGbd96wLXngpuhtDJZSA2BO9LJqkWU0Imt5Ry+rUfHvzutnulV794Lo98HpfQIAAMgmkfuVtnDiUrlv7LL3xd/DDGcZNg8jnAMwKxCKvfjGP49sm7subp1vD/ceO61pXr7Fu/9fAADgDYHQ0AL3cJdh8yjCOYDc4JfeY7fhXU7fNgMAAGQbt2B9oS9xm986YAZBOAeQO5x61Z10NA4Uiysrz+4LfPwwfrcidz4d3gUAAHKMU+CWpFfW2Pcz5Vtit/ulAyYFeZZlWaYbkSnd3d0qKipSV1eXCgsLTTcHQKqc5qG7iR8SLg0MC8828W0tCbovHfdgna8/rAAAQI5p3mMH8ng+vKdJNYfScw4gu8UH2On3SoufcT7WaUi4lPlh4c177JBdErSrzTtxaqtbMPfx8C4AAJCjRo123t4W5r7GBeEcQPZyCrAttfbj7FWJveluBUgi+zLxQfDsHQMhu2m3/bOy3rk9qZh5n1S+OW3NAwAAyAi3uecN26SPP8rOUY2Gsc45gOzlFmBbau2l1fatHlg7s6NROvuu+9+VrOpnR6P05t5LX1Oz7t8Se787m+ye9KG0J1rhhEtrEwAAgAlua59Lvl7LPBnCOYDslWqAfWOXHdLj19SMSDYsPFydGPSHI1wt/ef3nfc5DVdP9oEVzctruQMAAG8r3yLN2+S8L9VRhD7CsHYA2SsQsueYR4ayD8XM++xe52TV2tO1bJnbXPeIkqDz9vjqpEf3s5QIAADwlrJy5w6U42/Yox4jHRGR+6HoP/vsPohwDiC7RYq/DTWgXz9Xummp+/6ORunwz5z3DXV+erJvfktC0jXT7GHzTh8y0fPlp93FUiIAAMBb3JZWO/xT+9Ft5KOUvSvujBDCOYDst/iZ2AJw8T3MTqKHxMcvxea03Jrba1Phdvxt35QufmwPl4+IfMhE2vROfewXDz77EAIAAD4QGS3YFk4exuNlesUdwwjnAHJDIDRwYQ6EUh8O7rQUW7Je+OEMJXf6RnjuemnKnbHBXLKP6XnfvQ0++xACAAA+EQgNb555plbcyQKEcwC5yS2sX+iz19WMVAB1W4otXnCFNPOrw7/4x88fD4TsoexOBhui76MPIQAA4CNDHZ0o2aMMk01V9BDCOQBvCIQSe9Cv/Vzqr48O5vHD4IfShujjh/MBdCmvAwAAyGZu88+Taam1pzf6oOOCcA7AG5wqpp9+K7XXTl/qPgz+UuaAO30ATV8qtbj0qEtSWYUvPnwAAIBPRc8/l2KrtZ9913lOuk9GFRLOAXjDpayVecPt9mOypdUi/4ZTb3qynnan4e5XjHf/xnjehuH/PwAAAHJB/GjDyLaORudwfqHPfeUbDyGcA/CGwYaCB1fY642/ssb9tZFvcOMdfEw68d8Dz+euGwjcqVRbj/8AigT2hu1S28Go17KuOQAA8DGnUYclodj7Nw+vbJNnWZZluhGZ0t3draKiInV1damwsNB0cwCkW7Il0h6sc15GrazC7q0OhKQXlkr/85tLb0fk30rFcOe3AwAAeFXk/uhCn3PHysz7pOD9OXPvlGoOJZwD8JaORuce6fLNgxyzzv4QOHbg0tvw5RrfVBUFAAAYMW/ulfatdt9/40Lpqy9nrj3DlGoOZVg7AG8JhKRlLw7eIx0dzCW7N/22b6YnnMcPsad3HAAAYOgGm7bY/jvp+1OlpT/zxD1WvukGAMCICITs3munC7Vb8biry+x56dFK/n/uU6qmx/2b4WrpuQX2t77PLbCfAwAAYHCBFO7D/vd9z9xj0XMOwH/cvoV9p15aWS8175E6m+ygPqvS3hddcT1+PfXiqdIHx+w/t+y1q7GXb0le/d0D3+4CAACMuPIt9v2X09zzaB64xyKcA/CfQEiafm9slXXJfj57lR3II6E8+jWRi30gNBDWnQqVRD4cGrY7//s+WasTAAAgLWZV2vdPboV/I3L8Hoth7QD86YY7nLenul56ZNj8qNHO+9vCifPaIwabPwUAAIBY5VvsFXEuv879mBy/xyKcA/Ant4v3UC/qQz2+rCKnv9EFAAAwJhCSvnlM+penpGs/F7tv7vqcv8diWDsAf4oUGIkeHjWci7rT33NjuXT6iPPx8zYM7e8HAABArMgURI+tiMM65wD8LV0X9cjf8187B4rDxYtfbx0AAACexzrnAJCK6EJvl/r3nDnqHMxn3icF7/fEN7oAAAAYGcw5B4B06Wxy3p4/imAOAACApAjnAJAuJcGhbQcAAAD+H+EcANJlVmViEC8JJa6ZDgAAAMRhzjkApNPKeql5jz3EvSRIMAcAAEBKCOcAkG6R5T0AAACAFDGsHQAAAAAAwwjnAAAAAAAYRjgHAAAAAMAwwjkAAAAAAIYRzgEAAAAAMIxwDgAAAACAYYRzAAAAAAAMI5wDAAAAAGAY4RwAAAAAAMMI5wAAAAAAGEY4BwAAAADAMMI5AAAAAACGEc4BAAAAADCMcA4AAAAAgGGEcwAAAAAADCOcAwAAAABgGOEcAAAAAADDCOcAAAAAABhGOAcAAAAAwDDCOQAAAAAAhhHOAQAAAAAwjHAOAAAAAIBhhHMAAAAAAAwjnAMAAAAAYBjhHAAAAAAAwwjnAAAAAAAYRjgHAAAAAMAwwjkAAAAAAIYRzgEAAAAAMOwTphuQSZZlSZK6u7sNtwQAAAAA4AeR/BnJo258Fc57enokSaWlpYZbAgAAAADwk56eHhUVFbnuz7MGi+8ecvHiRZ08eVJXXHGF8vLyTDcn63V3d6u0tFQnTpxQYWGh6eYAGcO5D7/i3Idfce7Drzj3M8OyLPX09GjChAnKz3efWe6rnvP8/HwFAgHTzcg5hYWF/LLClzj34Vec+/Arzn34Fef+yEvWYx5BQTgAAAAAAAwjnAMAAAAAYBjhHK4KCgpUXV2tgoIC000BMopzH37FuQ+/4tyHX3HuZxdfFYQDAAAAACAb0XMOAAAAAIBhhHMAAAAAAAwjnAMAAAAAYBjhHAAAAAAAwwjnSKq3t1czZsxQXl6e/vKXv8Tsa2lp0W233aaxY8eqtLRU27dvN9NIIE2OHz+uBx54QJMmTdJll12mG264QdXV1Tp//nzMcZz78KIf/vCHuv766zV27FjNmTNHf/rTn0w3CUirrVu36uabb9YVV1yha665RnfffbdaW1tjjvnoo49UVVWlq666SpdffrmWLFmi06dPG2oxMDK2bdumvLw8rVu3rn8b5352IJwjqQ0bNmjChAkJ27u7u7Vo0SJNnDhRTU1N2rFjhzZv3qxnnnnGQCuB9Dh27JguXryompoavf3229q5c6d+/OMf67HHHus/hnMfXlRbW6tvfOMbqq6uVnNzs2666SZVVFTozJkzppsGpE1DQ4Oqqqr0xz/+UeFwWH19fVq0aJH++c9/9h+zfv167d+/Xy+99JIaGhp08uRJLV682GCrgfT685//rJqaGk2fPj1mO+d+lrAAF6+++qo1depU6+2337YkWYcPH+7f9/TTT1vjxo2zent7+7dt3LjRmjJlioGWAiNn+/bt1qRJk/qfc+7Di2bPnm1VVVX1P79w4YI1YcIEa+vWrQZbBYysM2fOWJKshoYGy7Is69y5c9bo0aOtl156qf+Yo0ePWpKsQ4cOmWomkDY9PT1WWVmZFQ6HrXnz5llr1661LItzP5vQcw5Hp0+f1sqVK7Vnzx598pOfTNh/6NAhfeELX9CYMWP6t1VUVKi1tVX/+Mc/MtlUYER1dXXpU5/6VP9zzn14zfnz59XU1KSFCxf2b8vPz9fChQt16NAhgy0DRlZXV5ck9V/jm5qa1NfXF/O7MHXqVH3605/mdwGeUFVVpS996Usx57jEuZ9NCOdIYFmWli9froceekihUMjxmFOnTunaa6+N2RZ5furUqRFvI5AJ7e3tevLJJ7V69er+bZz78Jq///3vunDhguN5zTkNr7p48aLWrVunuXPn6rOf/awk+xo+ZswYXXnllTHH8rsAL9i7d6+am5u1devWhH2c+9mDcO4jmzZtUl5eXtKfY8eO6cknn1RPT4++9a1vmW4ykBapnvvROjs79cUvflH33HOPVq5caajlAICRUFVVpSNHjmjv3r2mmwKMuBMnTmjt2rX6+c9/rrFjx5puDpL4hOkGIHMeffRRLV++POkxkydPVn19vQ4dOqSCgoKYfaFQSMuWLdPzzz+v8ePHJ1RwjDwfP358WtsNXKpUz/2IkydP6vbbb9fnP//5hEJvnPvwmquvvlqjRo1yPK85p+FFa9as0YEDB/T6668rEAj0bx8/frzOnz+vc+fOxfQg8ruAXNfU1KQzZ85o1qxZ/dsuXLig119/XU899ZQOHjzIuZ8lCOc+UlxcrOLi4kGP+8EPfqAnnnii//nJkydVUVGh2tpazZkzR5J0yy236Nvf/rb6+vo0evRoSVI4HNaUKVM0bty4kfkPAMOU6rkv2T3mt99+u4LBoHbv3q38/NgBRpz78JoxY8YoGAyqrq5Od999tyR7yG9dXZ3WrFljtnFAGlmWpUceeUT79u3T73//e02aNClmfzAY1OjRo1VXV6clS5ZIklpbW/Xee+/plltuMdFkIC0WLFigt956K2bbihUrNHXqVG3cuFGlpaWc+1kiz7Isy3QjkN2OHz+uSZMm6fDhw5oxY4Yku4jKlClTtGjRIm3cuFFHjhzR1772Ne3cuVOrVq0y22BgmDo7OzV//nxNnDhRzz//vEaNGtW/L/LNMec+vKi2tlb333+/ampqNHv2bO3atUsvvviijh07ljAXHchVX//61/XCCy/oV7/6laZMmdK/vaioSJdddpkk6eGHH9arr76qn/zkJyosLNQjjzwiSfrDH/5gpM3ASJk/f75mzJihXbt2SeLczxb0nGNYioqK9Nprr6mqqkrBYFBXX321Hn/8ccIJclo4HFZ7e7va29tjhjpKdo+LxLkPb7r33nv1wQcf6PHHH9epU6c0Y8YM/fa3vyWYw1N+9KMfSbJDSbTdu3f3T33auXOn8vPztWTJEvX29qqiokJPP/10hlsKZB7nfnag5xwAAAAAAMOo1g4AAAAAgGGEcwAAAAAADCOcAwAAAABgGOEcAAAAAADDCOcAAAAAABhGOAcAAAAAwDDCOQAAAAAAhhHOAQAAAAAwjHAOAAAAAIBhhHMAAAAAAAwjnAMAAAAAYBjhHAAAAAAAw/4Porog0zI09IEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# third party\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "syn_model.plot(plt, loader, plots=[\"tsne\"])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Done!\n",
+    "We have now generated synthetic data with synthcity starting from a dataset with missing values thanks to [HyperImpute](https://github.com/vanderschaarlab/hyperimpute). Visit the (HyperImpute tutorials)[https://github.com/vanderschaarlab/hyperimpute/tree/main/tutorials] for more details on how to impute data using the various different methods."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Congratulations!\n",
+    "\n",
+    "Congratulations on completing this notebook tutorial! If you enjoyed this and would like to join the movement towards Machine learning and AI for medicine, you can do so in the following ways!\n",
+    "\n",
+    "### Star [Synthcity](https://github.com/vanderschaarlab/synthcity) on GitHub\n",
+    "\n",
+    "- The easiest way to help our community is just by starring the Repos! This helps raise awareness of the tools we're building.\n",
+    "\n",
+    "\n",
+    "### Checkout other projects from vanderschaarlab\n",
+    "- [HyperImpute](https://github.com/vanderschaarlab/hyperimpute) - the module you have just learnt to use for synthcity!\n",
+    "- [AutoPrognosis](https://github.com/vanderschaarlab/autoprognosis)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "synthcity-all2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description
Add a tutorial for dealing with missingness with HyperImpute before using Synthcity to generate synthetic data.

## Affected Dependencies
None. HyperImpute is required for the tutorial, but is is recommended to be install separately, so that there isn't an absolute requirement for the dependencies for the two packages to be synced.

## How has this been tested?
No automated testing is enabled for this tutorial. As there is no new source code added, no tests are required. The notebook running should be a sufficient check. 

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
