### PR TITLE
Bugfix: fix mistake in _evaluate_performance_regression

### DIFF
--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -134,9 +134,9 @@ class PerformanceEvaluator(MetricEvaluator):
             The lower the negative value, the bigger the error in the predictions.
         """
 
-        X_train = np.asarray(X_test)
+        X_train = np.asarray(X_train)
         X_test = np.asarray(X_test)
-        y_train = np.asarray(y_test)
+        y_train = np.asarray(y_train)
         y_test = np.asarray(y_test)
 
         try:


### PR DESCRIPTION
## Description
This fixes a mistake in `_evaluate_performance_regression` where `X_train` was set to `X_test`. This PR closes #202.

## Affected Dependencies
None

## How has this been tested?
There are tests covering this code, but do not specifically check the mistake that was present, now fixed.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
