### PR TITLE
Add domain adaptation to becnhmarks

### DIFF
--- a/src/synthcity/benchmark/__init__.py
+++ b/src/synthcity/benchmark/__init__.py
@@ -111,7 +111,7 @@ class Benchmarks:
 
         workspace.mkdir(parents=True, exist_ok=True)
 
-        plugin_cats = ["generic", "privacy"]
+        plugin_cats = ["generic", "privacy", "domain_adaptation"]
         if X.type() == "images":
             plugin_cats.append("images")
         elif task_type == "survival_analysis":


### PR DESCRIPTION
## Description
Add domain adaptation to the plugin cats in benchmarks. This makes domain adaptation plugins like radialgan available to banchmark.


## Affected Dependencies
None

## How has this been tested?
Covered by existing tests

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
