### PR TITLE
pin pydantic version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     shap
     tqdm
     loguru
-    pydantic
+    pydantic<2.0
     cloudpickle
     scipy
     xgboost


### PR DESCRIPTION
## Description
pydantic<2.0 set in setup.cfg. The version pin should be removed but code needs migrating to v2 compatible.

## Affected Dependencies
None

## How has this been tested?
- No new tests required

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
