### PR TITLE
225 add a plugin registry

### DIFF
--- a/src/synthcity/plugins/core/plugin.py
+++ b/src/synthcity/plugins/core/plugin.py
@@ -34,6 +34,9 @@ from synthcity.utils.constants import DEVICE
 from synthcity.utils.reproducibility import enable_reproducible_results
 from synthcity.utils.serialization import load_from_file, save_to_file
 
+PLUGIN_NAME_NOT_SET: str = "plugin_name_not_set"
+PLUGIN_TYPE_NOT_SET: str = "plugin_type_not_set"
+
 
 class Plugin(Serializable, metaclass=ABCMeta):
     """
@@ -82,6 +85,15 @@ class Plugin(Serializable, metaclass=ABCMeta):
         compress_dataset: bool = False,
         sampling_strategy: str = "marginal",  # uniform, marginal
     ) -> None:
+        if self.name() == PLUGIN_NAME_NOT_SET:
+            raise ValueError(
+                f"Plugin {self.__class__.__name__} `name` was not set, use Plugins().add({self.__class__.__name__}, {self.__class__})"
+            )
+        if self.type() == PLUGIN_TYPE_NOT_SET:
+            raise ValueError(
+                f"Plugin {self.__class__.__name__} `type` was not set, use Plugins().add({self.__class__.__name__}, {self.__class__})"
+            )
+
         super().__init__()
 
         enable_reproducible_results(random_state)
@@ -145,13 +157,13 @@ class Plugin(Serializable, metaclass=ABCMeta):
     @abstractmethod
     def name() -> str:
         """The name of the plugin."""
-        ...
+        return PLUGIN_NAME_NOT_SET
 
     @staticmethod
     @abstractmethod
     def type() -> str:
         """The type of the plugin."""
-        ...
+        return PLUGIN_TYPE_NOT_SET
 
     @classmethod
     def fqdn(cls) -> str:
@@ -537,6 +549,10 @@ class Plugin(Serializable, metaclass=ABCMeta):
             plot_tsne(plt, X, X_syn)
 
 
+PLUGIN_CATEGORY_REGISTRY: Dict[str, Type[Plugin]] = dict()
+PLUGIN_REGISTRY: Dict[str, Type[Plugin]] = dict()
+
+
 class PluginLoader:
     """Plugin loading utility class.
     Used to load the plugins from the current folder.
@@ -544,7 +560,7 @@ class PluginLoader:
 
     @validate_arguments
     def __init__(self, plugins: list, expected_type: Type, categories: list) -> None:
-        self._plugins: Dict[str, Type] = {}
+        self._refresh()
         self._available_plugins = {}
         for plugin in plugins:
             stem = Path(plugin).stem.split("plugin_")[-1]
@@ -554,6 +570,9 @@ class PluginLoader:
             self._available_plugins[stem] = plugin
         self._expected_type = expected_type
         self._categories = categories
+
+    def _refresh(self) -> None:
+        self._plugins: Dict[str, Type[Plugin]] = PLUGIN_REGISTRY
 
     @validate_arguments
     def _load_single_plugin_impl(self, plugin_name: str) -> Optional[Type]:
@@ -610,6 +629,7 @@ class PluginLoader:
 
     def list(self) -> List[str]:
         """Get all the available plugins."""
+        self._refresh()
         all_plugins = list(self._plugins.keys()) + list(self._available_plugins.keys())
         plugins = []
         for plugin in all_plugins:
@@ -620,10 +640,24 @@ class PluginLoader:
 
     def types(self) -> List[Type]:
         """Get the loaded plugins types"""
+        self._refresh()
         return list(self._plugins.values())
+
+    def _add_category(self, category: str, expected_class: Type) -> "PluginLoader":
+        """Add a new plugin category"""
+        log.debug(f"Registering plugin category {category}")
+        if category in PLUGIN_CATEGORY_REGISTRY:
+            raise TypeError(f"Plugin category {category} already registered")
+        if not issubclass(expected_class, Plugin):
+            raise TypeError(
+                f"Plugin expected class for category should be a subclass of {Plugin} but was {expected_class}"
+            )
+        PLUGIN_CATEGORY_REGISTRY[category] = expected_class
+        return self
 
     def add(self, name: str, cls: Type) -> "PluginLoader":
         """Add a new plugin"""
+        self._refresh()
         if name in self._plugins:
             log.info(f"Plugin {name} already exists. Overwriting")
 
@@ -631,7 +665,9 @@ class PluginLoader:
             raise ValueError(
                 f"Plugin {name} must derive the {self._expected_type} interface."
             )
-        self._plugins[name] = cls
+        if cls not in PLUGIN_CATEGORY_REGISTRY.values():
+            self._add_category(cls.type, cls)
+        PLUGIN_REGISTRY[name] = cls
         return self
 
     @validate_arguments
@@ -649,6 +685,7 @@ class PluginLoader:
         Returns:
             The new object
         """
+        self._refresh()
         if name not in self._plugins and name not in self._available_plugins:
             raise ValueError(f"Plugin {name} doesn't exist.")
 
@@ -669,6 +706,7 @@ class PluginLoader:
         Returns:
             The class of the plugin
         """
+        self._refresh()
         if name not in self._plugins and name not in self._available_plugins:
             raise ValueError(f"Plugin {name} doesn't exist.")
 
@@ -682,6 +720,7 @@ class PluginLoader:
 
     def __iter__(self) -> Generator:
         """Iterate the loaded plugins."""
+        self._refresh()
         for x in self._plugins:
             yield x
 

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -4,6 +4,7 @@ import json
 import platform
 from copy import copy
 from pathlib import Path
+from typing import Any, List
 
 # third party
 import pytest
@@ -13,10 +14,15 @@ from sklearn.datasets import load_diabetes, load_iris
 # synthcity absolute
 from synthcity.benchmark import Benchmarks
 from synthcity.benchmark.utils import get_json_serializable_kwargs
+from synthcity.plugins import Plugins
 from synthcity.plugins.core.dataloader import (
+    DataLoader,
     GenericDataLoader,
     SurvivalAnalysisDataLoader,
 )
+from synthcity.plugins.core.distribution import Distribution
+from synthcity.plugins.core.plugin import Plugin
+from synthcity.plugins.core.schema import Schema
 
 
 def test_benchmark_sanity() -> None:
@@ -286,3 +292,57 @@ def test_benchmark_workspace_cache() -> None:
 
         assert X_augment_cache_file.exists()
         assert augment_generator_file.exists()
+
+
+def test_benchmark_added_plugin() -> None:
+    X, y = load_iris(return_X_y=True, as_frame=True)
+    X["target"] = y
+
+    class DummyCopyDataPlugin(Plugin):
+        """Dummy plugin for debugging."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+        @staticmethod
+        def name() -> str:
+            return "copy_data"
+
+        @staticmethod
+        def type() -> str:
+            return "debug"
+
+        @staticmethod
+        def hyperparameter_space(*args: Any, **kwargs: Any) -> List[Distribution]:
+            return []
+
+        def _fit(
+            self, X: DataLoader, *args: Any, **kwargs: Any
+        ) -> "DummyCopyDataPlugin":
+            self.features_count = X.shape[1]
+            self.X = X
+            return self
+
+        def _generate(
+            self, count: int, syn_schema: Schema, **kwargs: Any
+        ) -> DataLoader:
+            return self.X.sample(count)
+
+    generators = Plugins()
+    assert "copy_data" not in generators.list()
+    # Add the new plugin to the collection
+    generators.add("copy_data", DummyCopyDataPlugin)
+    assert "copy_data" in generators.list()
+
+    score = Benchmarks.evaluate(
+        [
+            ("copy_data", "copy_data", {}),
+        ],
+        GenericDataLoader(X, target_column="target"),
+        metrics={
+            "performance": [
+                "linear_model",
+            ]
+        },
+    )
+    assert "copy_data" in score

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -329,10 +329,8 @@ def test_benchmark_added_plugin() -> None:
             return self.X.sample(count)
 
     generators = Plugins()
-    assert "copy_data" not in generators.list()
     # Add the new plugin to the collection
     generators.add("copy_data", DummyCopyDataPlugin)
-    assert "copy_data" in generators.list()
 
     score = Benchmarks.evaluate(
         [

--- a/tests/plugins/test_plugin_add.py
+++ b/tests/plugins/test_plugin_add.py
@@ -58,6 +58,6 @@ def test_add_dummy_plugin() -> None:
     gen.generate(count=10)
 
     # Test that the new plugin is in the list of available plugins
-    generators = Plugins()
-    available_plugins = generators.list()
+    available_plugins = Plugins().list()
+    print(available_plugins)
     assert "copy_data" in available_plugins

--- a/tests/plugins/test_plugin_add.py
+++ b/tests/plugins/test_plugin_add.py
@@ -41,9 +41,11 @@ class DummyCopyDataPlugin(Plugin):
 
 def test_add_dummy_plugin() -> None:
     generators = Plugins()
+    print(Plugins().list())
     assert "copy_data" not in generators.list()
     # Add the new plugin to the collection
     generators.add("copy_data", DummyCopyDataPlugin)
+    print(Plugins().list())
 
     # Load reference data
     X, y = load_breast_cancer(return_X_y=True, as_frame=True)
@@ -59,5 +61,4 @@ def test_add_dummy_plugin() -> None:
 
     # Test that the new plugin is in the list of available plugins
     available_plugins = Plugins().list()
-    print(available_plugins)
     assert "copy_data" in available_plugins

--- a/tests/plugins/test_plugin_add.py
+++ b/tests/plugins/test_plugin_add.py
@@ -1,0 +1,63 @@
+# stdlib
+from typing import Any, List
+
+# third party
+from sklearn.datasets import load_breast_cancer
+
+# synthcity absolute
+from synthcity.plugins import Plugins
+from synthcity.plugins.core.dataloader import DataLoader, GenericDataLoader
+from synthcity.plugins.core.distribution import Distribution
+from synthcity.plugins.core.plugin import Plugin
+from synthcity.plugins.core.schema import Schema
+
+
+class DummyCopyDataPlugin(Plugin):
+    """Dummy plugin for debugging."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def name() -> str:
+        return "copy_data"
+
+    @staticmethod
+    def type() -> str:
+        return "debug"
+
+    @staticmethod
+    def hyperparameter_space(*args: Any, **kwargs: Any) -> List[Distribution]:
+        return []
+
+    def _fit(self, X: DataLoader, *args: Any, **kwargs: Any) -> "DummyCopyDataPlugin":
+        self.features_count = X.shape[1]
+        self.X = X
+        return self
+
+    def _generate(self, count: int, syn_schema: Schema, **kwargs: Any) -> DataLoader:
+        return self.X.sample(count)
+
+
+def test_add_dummy_plugin() -> None:
+    generators = Plugins()
+    assert "copy_data" not in generators.list()
+    # Add the new plugin to the collection
+    generators.add("copy_data", DummyCopyDataPlugin)
+
+    # Load reference data
+    X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+    loader = GenericDataLoader(X)
+    loader.dataframe()
+
+    # Train the new plugin
+    gen = generators.get("copy_data")
+    gen.fit(loader)
+
+    # Generate some new data
+    gen.generate(count=10)
+
+    # Test that the new plugin is in the list of available plugins
+    generators = Plugins()
+    available_plugins = generators.list()
+    assert "copy_data" in available_plugins

--- a/tests/plugins/test_plugin_add.py
+++ b/tests/plugins/test_plugin_add.py
@@ -1,4 +1,6 @@
 # stdlib
+import glob
+from pathlib import Path
 from typing import Any, List
 
 # third party
@@ -40,12 +42,21 @@ class DummyCopyDataPlugin(Plugin):
 
 
 def test_add_dummy_plugin() -> None:
+    # get the list of plugins that are loaded
     generators = Plugins()
-    print(Plugins().list())
-    assert "copy_data" not in generators.list()
-    # Add the new plugin to the collection
+
+    # Get the list of plugins that come with the package
+    plugins_dir = Path.cwd() / "src/synthcity/plugins"
+    plugins_list = []
+    for plugin_type in plugins_dir.iterdir():
+        plugin_paths = glob.glob(str(plugins_dir / plugin_type / "plugin*.py"))
+        plugins_list.extend([Path(path).stem for path in plugin_paths])
+
+    # Test that the new plugin is not in the list plugins in the package
+    assert "copy_data" not in plugins_list
+
+    # Add the new plugin
     generators.add("copy_data", DummyCopyDataPlugin)
-    print(Plugins().list())
 
     # Load reference data
     X, y = load_breast_cancer(return_X_y=True, as_frame=True)
@@ -56,9 +67,9 @@ def test_add_dummy_plugin() -> None:
     gen = generators.get("copy_data")
     gen.fit(loader)
 
-    # Generate some new data
+    # Generate some new data to check the new plugin works
     gen.generate(count=10)
 
-    # Test that the new plugin is in the list of available plugins
+    # Test that the new plugin is now in the list of available plugins
     available_plugins = Plugins().list()
     assert "copy_data" in available_plugins


### PR DESCRIPTION
## Description
This PR allows plugins that have been added by the user at runtime to be stored in the Plugins() context. The most important benefit of which is that it makes these user added plugins available to `Benchmarks.evaluate()`. This is achieved by the addition of two dictionary objects: `"PLUGIN_REGISTRY"` and  `"PLUGIN_CATEGORY_REGISTRY"` to `plugin.py`. These dictionaries store all the plugins that get added by the `PluginLoader`. A new `PluginLoader._refresh()` function sets the values of these new dictionaries to `self._plugins` and `self._categories`. `_refresh` is called by all the functions that access the `_plugins` of `_categories` attributes, meaning that added plugins are always available.

closes #225 

## Affected Dependencies
None

## How has this been tested?
- New tests added:
  - tests/plugins/test_plugin_add.py checks an added plugin is available from `synthcity.plugins.Plugins().list()`
  - tests/benchmarks/test_benchmarks.py::test_benchmark_added_plugin checks that added plugins are available to `Benchmarks.evaluate()`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
