### PR TITLE
Fix time series dataloader bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     pydantic<2.0
     cloudpickle
     scipy
-    xgboost
+    xgboost<2.0.0
     geomloss
     pgmpy
     redis

--- a/src/synthcity/plugins/core/dataloader.py
+++ b/src/synthcity/plugins/core/dataloader.py
@@ -932,7 +932,7 @@ class TimeSeriesDataLoader(DataLoader):
             longest_observation_seq = max([len(seq) for seq in temporal_data])
             return (
                 np.asarray(static_data),
-                np.asarray(pd.concat(temporal_data)),
+                np.asarray(temporal_data),
                 # masked array to handle variable length sequences
                 ma.vstack(
                     [


### PR DESCRIPTION
## Description
- Fix time series dataloader bug
- Hotfix: Pin the version of xgboost in setup.cfg to avoid breaking changes.
  - We will need to migrate to xgboost 2.0.0 at some future point.
 
## Affected Dependencies
xgboost pinned to <2.0.0, where previously it accepted the latest version 

## How has this been tested?
Usual test suite.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
