### PR TITLE
reuse encoders for ordinal variables [type:bug]

### DIFF
--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -200,15 +200,15 @@ class Metrics:
         if metrics is None:
             metrics = Metrics.list()
 
-        X_gt, _ = X_gt.encode()
-        X_syn, _ = X_syn.encode()
+        X_gt, encoders = X_gt.encode()
+        X_syn, _ = X_syn.encode(encoders)
 
         if X_train:
-            X_train, _ = X_train.encode()
+            X_train, _ = X_train.encode(encoders)
         if X_ref_syn:
-            X_ref_syn, _ = X_ref_syn.encode()
+            X_ref_syn, _ = X_ref_syn.encode(encoders)
         if X_augmented:
-            X_augmented, _ = X_augmented.encode()
+            X_augmented, _ = X_augmented.encode(encoders)
 
         scores = ScoreEvaluator()
 


### PR DESCRIPTION
## Description
Fixes https://github.com/vanderschaarlab/synthcity/issues/250#issue-2102043850

## Notes
- Only quick fix. Sklearn recommends _against_ using LabelEncoder for features, I have not changed this.
- Results in error when there are unknown feature classes in e.g. X_syn (compared to X_gt). This is safer, though does mean we cannot evaluate easily on a very small real dataset. If we want to avoid this, we could use OrdinalEncoder instead, which allows ignore_unknown argument to be passed

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
