### PR TITLE
update onehotencoder parameters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     importlib-metadata
     pandas>=1.4,<2
     torch>=1.10.0,<2.0
-    scikit-learn>=1.0
+    scikit-learn>=1.2
     nflows>=0.14
     numpy>=1.20, <1.24
     lifelines>=0.27,!= 0.27.5

--- a/src/synthcity/plugins/core/models/tabular_encoder.py
+++ b/src/synthcity/plugins/core/models/tabular_encoder.py
@@ -60,7 +60,7 @@ class TabularEncoder(TransformerMixin, BaseEstimator):
 
     categorical_encoder: Union[str, type] = "onehot"
     continuous_encoder: Union[str, type] = "bayesian_gmm"
-    cat_encoder_params: dict = dict(handle_unknown="ignore", sparse=False)
+    cat_encoder_params: dict = dict(handle_unknown="ignore", sparse_output=False)
     cont_encoder_params: dict = dict(n_components=10)
 
     @validate_arguments(config=dict(arbitrary_types_allowed=True))


### PR DESCRIPTION
## Description
Updated the `OneHotEncoder` parameters, now 'sparse' is deprecated in `sklearn==1.4`.

## Affected Dependencies
New minimum version of sklearn.
scikit-learn>=1.2

## How has this been tested?
This is a minimal change that is covered by the existing test suite.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
