### PR TITLE
Metrics: ensure ordinal encoder of classes is the same in real and synthetic datasets [type:bug]

### DIFF
--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -202,18 +202,18 @@ class Metrics:
 
         """
         We need to encode the categorical data in the real and synthetic data.
-        To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
+        To ensure each category in the two datasets are mapped to the same one hot vector, we merge X_syn into X_gt for computing the encoder.
+        TODO: Check whether the optional datasets also need to be taking into account when getting the encoder.
         """
         X_gt_df = X_gt.dataframe()
         X_syn_df = X_syn.dataframe()
         X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
         _, encoders = X_enc.encode()
 
+        # now we encode the data
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
-        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -207,19 +207,12 @@ class Metrics:
         We need to encode the categorical data in the real and synthetic data. 
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
-        len_x_gt = len(X_gt.data)
-        if isinstance(X_gt.data, pd.DataFrame):
-            X_gt.data = pd.concat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, torch.Tensor):
-            X_gt.data = torch.cat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, np.ndarray):
-            X_gt.data = np.concatenate([X_gt.data, X_syn.data],axis=0)
+        X_gt_df = X_gt.dataframe()
+        X_syn_df = X_syn.dataframe()
+        X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
+        _, encoders = X_enc.encode()
 
-        X_gt, encoders = X_gt.encode()
-        # Reset the data to the original length, to remove the synthetic data
-        X_gt.data = X_gt.data.iloc[:len_x_gt]
-
-        # Encode the synthetic data and other datasets
+        X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
         # TODO: Check whether the below also need to share the same encoders

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -201,7 +201,7 @@ class Metrics:
             metrics = Metrics.list()
 
         """
-        We need to encode the categorical data in the real and synthetic data. 
+        We need to encode the categorical data in the real and synthetic data.
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
         X_gt_df = X_gt.dataframe()
@@ -212,7 +212,8 @@ class Metrics:
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders
+        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
+        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -1,12 +1,9 @@
 # stdlib
-import copy
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 # third party
-import numpy as np
 import pandas as pd
-import torch
 from pydantic import validate_arguments
 
 # synthcity absolute

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -200,15 +200,15 @@ class Metrics:
         if metrics is None:
             metrics = Metrics.list()
 
-        X_gt, _ = X_gt.encode()
-        X_syn, _ = X_syn.encode()
+        X_gt, encoders = X_gt.encode()
+        X_syn, _ = X_syn.encode(encoders)
 
         if X_train:
-            X_train, _ = X_train.encode()
+            X_train, _ = X_train.encode(encoders)
         if X_ref_syn:
-            X_ref_syn, _ = X_ref_syn.encode()
+            X_ref_syn, _ = X_ref_syn.encode(encoders)
         if X_augmented:
-            X_augmented, _ = X_augmented.encode()
+            X_augmented, _ = X_augmented.encode(encoders)
 
         scores = ScoreEvaluator()
 


### PR DESCRIPTION
## Description
Fixes https://github.com/vanderschaarlab/synthcity/issues/250#issue-2102043850, by ensuring the ordinal encoders are fitted to the real and synthetic data concatenated.

## Affected dependencies
None

## Notes
- A quick fix that ensure the same encoder is used for real and synthetic data ordinal encodings. We may need to have a longer discussion on whether this is always preferential, and whether other optional datasets (e.g. augmented, reference) need to also be included in the encoder processing. 
- Also note, Sklearn recommends _against_ using LabelEncoder for features, I have not changed this to keep the PR minimal.
- When both datasets have the same classes (which was assumed by the previous code), functionality is identical

## How has this been tested?
- Ran quick testing suit, giving "2159 passed, 13 skipped, 106 deselected, 2 xfailed, 2896 warnings"

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
