### PR TITLE
pin networkx < 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     numpy>=1.20, <1.24
     lifelines>=0.27,!= 0.27.5, <0.27.8
     opacus>=1.3
+    networkx>2.0,<3.0
     decaf-synthetic-data>=0.1.6
     optuna>=3.1
     shap


### PR DESCRIPTION
## Description
Pin `networkx<3.0` to stop `decaf` errors, due to:
```
tests/plugins/test_plugin_serialization.py::test_serialization_privacy_plugins[decaf]
```
closes #258 

## Affected Dependencies
Add pin `networkx<3.0` 

## How has this been tested?
- All current related tests pass, where they didn't previously.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
