### PR TITLE
Classification metric fix [type:bug]

### DIFF
--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -202,18 +202,18 @@ class Metrics:
 
         """
         We need to encode the categorical data in the real and synthetic data.
-        To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
+        To ensure each category in the two datasets are mapped to the same one hot vector, we merge X_syn into X_gt for computing the encoder.
+        TODO: Check whether the optional datasets also need to be taking into account when getting the encoder.
         """
         X_gt_df = X_gt.dataframe()
         X_syn_df = X_syn.dataframe()
         X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
         _, encoders = X_enc.encode()
 
+        # now we encode the data
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
-        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -207,19 +207,12 @@ class Metrics:
         We need to encode the categorical data in the real and synthetic data. 
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
-        len_x_gt = len(X_gt.data)
-        if isinstance(X_gt.data, pd.DataFrame):
-            X_gt.data = pd.concat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, torch.Tensor):
-            X_gt.data = torch.cat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, np.ndarray):
-            X_gt.data = np.concatenate([X_gt.data, X_syn.data],axis=0)
+        X_gt_df = X_gt.dataframe()
+        X_syn_df = X_syn.dataframe()
+        X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
+        _, encoders = X_enc.encode()
 
-        X_gt, encoders = X_gt.encode()
-        # Reset the data to the original length, to remove the synthetic data
-        X_gt.data = X_gt.data.iloc[:len_x_gt]
-
-        # Encode the synthetic data and other datasets
+        X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
         # TODO: Check whether the below also need to share the same encoders

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -201,7 +201,7 @@ class Metrics:
             metrics = Metrics.list()
 
         """
-        We need to encode the categorical data in the real and synthetic data. 
+        We need to encode the categorical data in the real and synthetic data.
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
         X_gt_df = X_gt.dataframe()
@@ -212,7 +212,8 @@ class Metrics:
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders
+        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
+        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -1,12 +1,9 @@
 # stdlib
-import copy
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 # third party
-import numpy as np
 import pandas as pd
-import torch
 from pydantic import validate_arguments
 
 # synthcity absolute

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -200,15 +200,15 @@ class Metrics:
         if metrics is None:
             metrics = Metrics.list()
 
-        X_gt, _ = X_gt.encode()
-        X_syn, _ = X_syn.encode()
+        X_gt, encoders = X_gt.encode()
+        X_syn, _ = X_syn.encode(encoders)
 
         if X_train:
-            X_train, _ = X_train.encode()
+            X_train, _ = X_train.encode(encoders)
         if X_ref_syn:
-            X_ref_syn, _ = X_ref_syn.encode()
+            X_ref_syn, _ = X_ref_syn.encode(encoders)
         if X_augmented:
-            X_augmented, _ = X_augmented.encode()
+            X_augmented, _ = X_augmented.encode(encoders)
 
         scores = ScoreEvaluator()
 

--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -179,12 +179,18 @@ class PerformanceEvaluator(MetricEvaluator):
 
         if self._task_type == "classification":
             eval_cbk = self._evaluate_performance_classification
+            skf = StratifiedKFold(
+                n_splits=self._n_folds, shuffle=True, random_state=self._random_state
+            )
         elif self._task_type == "regression":
             eval_cbk = self._evaluate_performance_regression
+            skf = KFold(
+                n_splits=self._n_folds, shuffle=True, random_state=self._random_state
+            )
 
-        skf = StratifiedKFold(
-            n_splits=self._n_folds, shuffle=True, random_state=self._random_state
-        )
+        print("############## Task", self._task_type)
+        print(self._n_folds, self._random_state, self._task_type)
+        print(model, model_args)
 
         real_scores = []
         syn_scores_id = []

--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -886,15 +886,16 @@ class PerformanceEvaluatorMLP(PerformanceEvaluator):
             if X_gt.type() == "images":
                 return self._evaluate_images(X_gt, X_syn)
 
-            mlp_args = {
+            model_args = {
                 "n_units_in": X_gt.shape[1] - 1,
                 "n_units_out": 1,
                 "random_state": self._random_state,
+                "task_type": self._task_type,
             }
-            mlp_args["task_type"] = self._task_type
 
             return self._evaluate_standard_performance(
                 MLP,
+                model_args,
                 X_gt,
                 X_syn,
             )

--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -153,10 +153,8 @@ class PerformanceEvaluator(MetricEvaluator):
     @validate_arguments(config=dict(arbitrary_types_allowed=True))
     def _evaluate_standard_performance(
         self,
-        clf_model: Any,
-        clf_args: Dict,
-        regression_model: Any,
-        regression_args: Any,
+        model: Any,
+        model_args: Dict,
         X_gt: DataLoader,
         X_syn: DataLoader,
     ) -> Dict:
@@ -179,20 +177,14 @@ class PerformanceEvaluator(MetricEvaluator):
         ood_X_gt, ood_y_gt = X_gt.test().unpack()
         iter_X_syn, iter_y_syn = X_syn.unpack()
 
-        if len(id_y_gt.unique()) < 5:
+        if self._task_type == "classification":
             eval_cbk = self._evaluate_performance_classification
-            skf = StratifiedKFold(
-                n_splits=self._n_folds, shuffle=True, random_state=self._random_state
-            )
-            model = clf_model
-            model_args = clf_args
-        else:
+        elif self._task_type == "regression":
             eval_cbk = self._evaluate_performance_regression
-            model = regression_model
-            model_args = regression_args
-            skf = KFold(
-                n_splits=self._n_folds, shuffle=True, random_state=self._random_state
-            )
+
+        skf = StratifiedKFold(
+            n_splits=self._n_folds, shuffle=True, random_state=self._random_state
+        )
 
         real_scores = []
         syn_scores_id = []
@@ -680,19 +672,21 @@ class PerformanceEvaluatorXGB(PerformanceEvaluator):
                 X_syn,
             )
         elif self._task_type == "classification" or self._task_type == "regression":
-            xgb_clf_args = {
+            if self._task_type == "classification":
+                model = XGBClassifier
+            else:
+                model = XGBRegressor
+
+            model_args = {
                 "n_jobs": 2,
                 "verbosity": 0,
                 "depth": 3,
                 "random_state": self._random_state,
             }
 
-            xgb_reg_args = copy.deepcopy(xgb_clf_args)
             return self._evaluate_standard_performance(
-                XGBClassifier,
-                xgb_clf_args,
-                XGBRegressor,
-                xgb_reg_args,
+                model,
+                model_args,
                 X_gt,
                 X_syn,
             )
@@ -743,10 +737,15 @@ class PerformanceEvaluatorLinear(PerformanceEvaluator):
     ) -> Dict:
         if self._task_type == "survival_analysis":
             return self._evaluate_survival_model(CoxPHSurvivalAnalysis, {}, X_gt, X_syn)
-        elif self._task_type == "classification" or self._task_type == "regression":
+        elif self._task_type == "classification":
             return self._evaluate_standard_performance(
                 LogisticRegression,
                 {"random_state": self._random_state},
+                X_gt,
+                X_syn,
+            )
+        elif self._task_type == "regression":
+            return self._evaluate_standard_performance(
                 LinearRegression,
                 {},
                 X_gt,
@@ -892,16 +891,10 @@ class PerformanceEvaluatorMLP(PerformanceEvaluator):
                 "n_units_out": 1,
                 "random_state": self._random_state,
             }
-            clf_args = copy.deepcopy(mlp_args)
-            clf_args["task_type"] = "classification"
-            reg_args = copy.deepcopy(mlp_args)
-            reg_args["task_type"] = "regression"
+            mlp_args["task_type"] = self._task_type
 
             return self._evaluate_standard_performance(
                 MLP,
-                clf_args,
-                MLP,
-                reg_args,
                 X_gt,
                 X_syn,
             )

--- a/src/synthcity/metrics/eval_performance.py
+++ b/src/synthcity/metrics/eval_performance.py
@@ -188,10 +188,6 @@ class PerformanceEvaluator(MetricEvaluator):
                 n_splits=self._n_folds, shuffle=True, random_state=self._random_state
             )
 
-        print("############## Task", self._task_type)
-        print(self._n_folds, self._random_state, self._task_type)
-        print(model, model_args)
-
         real_scores = []
         syn_scores_id = []
         syn_scores_ood = []

--- a/tests/plugins/core/models/test_gan.py
+++ b/tests/plugins/core/models/test_gan.py
@@ -169,7 +169,7 @@ def test_gan_generation_with_early_stopping(patience_metric: Tuple[str, str]) ->
         n_iter_print=20,
         patience=2,
         batch_size=len(X),
-        patience_metric=WeightedMetrics(metrics=[patience_metric], weights=[1]),
+        patience_metric=WeightedMetrics(metrics=[patience_metric], weights=[1], task_type="regression"),
         generator_extra_penalty_cbks=[_tracker],
     )
     model.fit(X)

--- a/tests/plugins/core/models/test_gan.py
+++ b/tests/plugins/core/models/test_gan.py
@@ -169,7 +169,9 @@ def test_gan_generation_with_early_stopping(patience_metric: Tuple[str, str]) ->
         n_iter_print=20,
         patience=2,
         batch_size=len(X),
-        patience_metric=WeightedMetrics(metrics=[patience_metric], weights=[1], task_type="regression"),
+        patience_metric=WeightedMetrics(
+            metrics=[patience_metric], weights=[1], task_type="regression"
+        ),
         generator_extra_penalty_cbks=[_tracker],
     )
     model.fit(X)

--- a/tests/plugins/core/models/test_tabular_gan.py
+++ b/tests/plugins/core/models/test_tabular_gan.py
@@ -164,7 +164,9 @@ def test_gan_generation_with_early_stopping(patience_metric: Tuple[str, str]) ->
         generator_n_iter=1000,
         encoder_max_clusters=5,
         patience=2,
-        patience_metric=WeightedMetrics(metrics=[patience_metric], weights=[1]),
+        patience_metric=WeightedMetrics(
+            metrics=[patience_metric], weights=[1], task_type="classification"
+        ),
     )
     model.fit(X)
 

--- a/tests/plugins/domain_adaptation/test_radialgan.py
+++ b/tests/plugins/domain_adaptation/test_radialgan.py
@@ -148,7 +148,7 @@ def test_eval_performance_radialgan() -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=500, batch_size=50)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/generic/test_arf.py
+++ b/tests/plugins/generic/test_arf.py
@@ -134,7 +134,7 @@ def test_eval_performance_arf(compress_dataset: bool) -> None:
 
     for retry in range(2):
         test_plugin = plugin(**plugin_args)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate(count=100)

--- a/tests/plugins/generic/test_ctgan.py
+++ b/tests/plugins/generic/test_ctgan.py
@@ -131,7 +131,7 @@ def test_eval_performance_ctgan(compress_dataset: bool) -> None:
             n_iter=5000,
             compress_dataset=compress_dataset,
         )
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/generic/test_ddpm.py
+++ b/tests/plugins/generic/test_ddpm.py
@@ -166,7 +166,7 @@ def test_eval_performance_ddpm(compress_dataset: bool) -> None:
 
     for _ in range(2):
         test_plugin = plugin(**plugin_params, compress_dataset=compress_dataset)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/generic/test_great.py
+++ b/tests/plugins/generic/test_great.py
@@ -168,7 +168,7 @@ def test_eval_performance_great(compress_dataset: bool) -> None:
 
     for retry in range(2):
         test_plugin = plugin(**plugin_args)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate(count=100, max_length=100)

--- a/tests/plugins/generic/test_nflow.py
+++ b/tests/plugins/generic/test_nflow.py
@@ -115,7 +115,7 @@ def test_eval_performance_nflow(compress_dataset: bool) -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=5000, compress_dataset=compress_dataset)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/generic/test_rtvae.py
+++ b/tests/plugins/generic/test_rtvae.py
@@ -110,7 +110,7 @@ def test_eval_performance_rtvae() -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=1000)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/generic/test_tvae.py
+++ b/tests/plugins/generic/test_tvae.py
@@ -114,7 +114,7 @@ def test_eval_performance_tvae() -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=1000)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/privacy/test_adsgan.py
+++ b/tests/plugins/privacy/test_adsgan.py
@@ -142,7 +142,7 @@ def test_eval_performance(compress_dataset: bool) -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=5000, compress_dataset=compress_dataset)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/privacy/test_aim.py
+++ b/tests/plugins/privacy/test_aim.py
@@ -146,7 +146,7 @@ def test_eval_performance_aim(compress_dataset: bool) -> None:
 
     for retry in range(2):
         test_plugin = plugin(**plugin_args)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate(count=1000)

--- a/tests/plugins/privacy/test_dpgan.py
+++ b/tests/plugins/privacy/test_dpgan.py
@@ -123,7 +123,7 @@ def test_eval_performance_dpgan() -> None:
 
     for retry in range(2):
         test_plugin = plugin(n_iter=300)
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()

--- a/tests/plugins/privacy/test_pategan.py
+++ b/tests/plugins/privacy/test_pategan.py
@@ -114,7 +114,7 @@ def test_eval_performance() -> None:
         test_plugin = plugin(
             n_iter=200, generator_n_layers_hidden=1, n_teachers=2, lamda=2e-4
         )
-        evaluator = PerformanceEvaluatorXGB()
+        evaluator = PerformanceEvaluatorXGB(task_type="classification")
 
         test_plugin.fit(X)
         X_syn = test_plugin.generate()


### PR DESCRIPTION
## Description
Ensures that when the task of a dataset is classification, we always use classification (and do not switch to R2). Minimal changes to the codebase. N.B. this is based off branch of PR #257.

## Affected Dependencies
None

## How has this been tested?
Standard fast tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
