### PR TITLE
Patch ctgan batchsize1

### DIFF
--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -202,18 +202,18 @@ class Metrics:
 
         """
         We need to encode the categorical data in the real and synthetic data.
-        To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
+        To ensure each category in the two datasets are mapped to the same one hot vector, we merge X_syn into X_gt for computing the encoder.
+        TODO: Check whether the optional datasets also need to be taking into account when getting the encoder.
         """
         X_gt_df = X_gt.dataframe()
         X_syn_df = X_syn.dataframe()
         X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
         _, encoders = X_enc.encode()
 
+        # now we encode the data
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
-        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -207,19 +207,12 @@ class Metrics:
         We need to encode the categorical data in the real and synthetic data. 
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
-        len_x_gt = len(X_gt.data)
-        if isinstance(X_gt.data, pd.DataFrame):
-            X_gt.data = pd.concat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, torch.Tensor):
-            X_gt.data = torch.cat([X_gt.data, X_syn.data],axis=0)
-        elif isinstance(X_gt.data, np.ndarray):
-            X_gt.data = np.concatenate([X_gt.data, X_syn.data],axis=0)
+        X_gt_df = X_gt.dataframe()
+        X_syn_df = X_syn.dataframe()
+        X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
+        _, encoders = X_enc.encode()
 
-        X_gt, encoders = X_gt.encode()
-        # Reset the data to the original length, to remove the synthetic data
-        X_gt.data = X_gt.data.iloc[:len_x_gt]
-
-        # Encode the synthetic data and other datasets
+        X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
         # TODO: Check whether the below also need to share the same encoders

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -201,7 +201,7 @@ class Metrics:
             metrics = Metrics.list()
 
         """
-        We need to encode the categorical data in the real and synthetic data. 
+        We need to encode the categorical data in the real and synthetic data.
         To ensure each category in the two datasets are mapped to the same index, we merge X_syn into X_gt for computing the encoder.
         """
         X_gt_df = X_gt.dataframe()
@@ -212,7 +212,8 @@ class Metrics:
         X_gt, _ = X_gt.encode(encoders)
         X_syn, _ = X_syn.encode(encoders)
 
-        # TODO: Check whether the below also need to share the same encoders
+        # TODO: Check whether the below also need to share the same encoders, and whether it's necessary to warn the user when
+        # there are classes that are not present in the training data but are present in one of these
         if X_train:
             X_train, _ = X_train.encode(encoders)
         if X_ref_syn:

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -1,12 +1,9 @@
 # stdlib
-import copy
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 # third party
-import numpy as np
 import pandas as pd
-import torch
 from pydantic import validate_arguments
 
 # synthcity absolute

--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -200,15 +200,15 @@ class Metrics:
         if metrics is None:
             metrics = Metrics.list()
 
-        X_gt, _ = X_gt.encode()
-        X_syn, _ = X_syn.encode()
+        X_gt, encoders = X_gt.encode()
+        X_syn, _ = X_syn.encode(encoders)
 
         if X_train:
-            X_train, _ = X_train.encode()
+            X_train, _ = X_train.encode(encoders)
         if X_ref_syn:
-            X_ref_syn, _ = X_ref_syn.encode()
+            X_ref_syn, _ = X_ref_syn.encode(encoders)
         if X_augmented:
-            X_augmented, _ = X_augmented.encode()
+            X_augmented, _ = X_augmented.encode(encoders)
 
         scores = ScoreEvaluator()
 

--- a/src/synthcity/plugins/core/models/gan.py
+++ b/src/synthcity/plugins/core/models/gan.py
@@ -682,7 +682,7 @@ class GAN(nn.Module):
         interpolated = (
             alpha * real_samples + ((1 - alpha) * fake_samples)
         ).requires_grad_(True)
-        d_interpolated = self.discriminator(interpolated).squeeze()
+        d_interpolated = self.discriminator(interpolated).squeeze(-1)
         labels = torch.ones((len(interpolated),), device=self.device)
 
         # Get gradient w.r.t. interpolates


### PR DESCRIPTION
## Description
Fixes CTGAN error when batch size=1 (e.g. which can happen for the last batch in the epoch). Literally only specifies to squeeze only the last dimension when computing the gradient (i.e. whole PR is adding "-1" as squeeze argument).

## Affected Dependencies
None

## How has this been tested?
- ran CTGAN to ensure it's now fixed
- ran fast tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
