### PR TITLE
change mac runner to macos-11

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-11, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Description
Change the github action mac runner to see if it stops the issue of hanging until timeout

## Affected Dependencies
None

## How has this been tested?
standard tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
