### PR TITLE
use all available datasets for computing the encoding of the categorcal data in the metrics evaluater

### DIFF
--- a/src/synthcity/metrics/eval.py
+++ b/src/synthcity/metrics/eval.py
@@ -203,12 +203,16 @@ class Metrics:
 
         """
         We need to encode the categorical data in the real and synthetic data.
-        To ensure each category in the two datasets are mapped to the same one hot vector, we merge X_syn into X_gt for computing the encoder.
-        TODO: Check whether the optional datasets also need to be taking into account when getting the encoder.
+        To ensure each category in the two datasets are mapped to the same one hot vector, we merge all avalable datasets for computing the encoder.
         """
-        X_gt_df = X_gt.dataframe()
-        X_syn_df = X_syn.dataframe()
-        X_enc = create_from_info(pd.concat([X_gt_df, X_syn_df]), X_gt.info())
+        all_df = pd.concat([X_gt.dataframe(), X_syn.dataframe()])
+        if X_train:
+            all_df = pd.concat([all_df, X_train.dataframe()])
+        if X_ref_syn:
+            all_df = pd.concat([all_df, X_ref_syn.dataframe()])
+        if X_augmented:
+            all_df = pd.concat([all_df, X_augmented.dataframe()])
+        X_enc = create_from_info(all_df, X_gt.info())
         _, encoders = X_enc.encode()
 
         # now we encode the data


### PR DESCRIPTION
## Description
In #257 the ordinal encoder in the metric evaluater was adapted to be fitted on the concatenated real and synthetic data. It left a TODO comment mentioning that maybe the optional datasets (`X_train`, `X_ref_syn` and `X_augmented`) should also be included.

With my relatively small dataset (~1000 points) I always got the error `y contains previously unseen labels: [...]` when running the Benchmarks. I traced the error back to the encoding of the `X_train` dataset. Due to the small size of the dataset the `X_train` set contained values that are not in the `X_gt` or `X_syn` sets and thus the LabelEncoder wasn't fitted on all categories.

With my change all available datasets are included for fitting the encoder.

## How has this been tested?

- Ran fast test suit
- Ran benchmarks with my own data which worked

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
