### PR TITLE
Fix the optimisation direction of DeltaPresence

### DIFF
--- a/src/synthcity/metrics/eval_privacy.py
+++ b/src/synthcity/metrics/eval_privacy.py
@@ -231,7 +231,7 @@ class DeltaPresence(PrivacyEvaluator):
 
     @staticmethod
     def direction() -> str:
-        return "maximize"
+        return "minimize"
 
     @validate_arguments(config=dict(arbitrary_types_allowed=True))
     def _evaluate(self, X_gt: DataLoader, X_syn: DataLoader) -> Dict:


### PR DESCRIPTION
## Description
In the context of privacy evaluation, delta presence should generally be minimized, not maximized, despite what the code's original `direction()` method suggests.

* Delta presence measures the re-identification probability - essentially how easy it is to identify individuals in the real dataset using information from the synthetic dataset.
* A higher delta presence score indicates a higher risk of re-identification, which is bad for privacy. The score represents the maximum ratio of unique sensitive information between the real and synthetic datasets.
* Looking at the code implementation:
  1. It calculates clusters in both real and synthetic data
  2. For each cluster, it computes the ratio: `delta = gt_cnt / (synth_cnt + 1e-8)`
  3. It returns the maximum of these ratios as the score
  4. A higher ratio means there's a greater disparity between real and synthetic data distributions, potentially making it easier to identify individuals

Therefore, the `direction()` method returning "maximize" appears to be incorrect. For better privacy protection, you would want to minimize the delta presence score to reduce re-identification risks.

## Affected Dependencies
None

## How has this been tested?
- Display the method's optimisation direction when executing the code.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
