### PR TITLE
add logging on failed tabular goggle import

### DIFF
--- a/src/synthcity/plugins/generic/plugin_goggle.py
+++ b/src/synthcity/plugins/generic/plugin_goggle.py
@@ -16,6 +16,7 @@ from pydantic import validate_arguments
 from torch.utils.data import sampler
 
 # synthcity absolute
+import synthcity.logger as log
 from synthcity.plugins.core.dataloader import DataLoader
 from synthcity.plugins.core.distribution import (
     CategoricalDistribution,
@@ -32,8 +33,9 @@ try:
     from synthcity.plugins.core.models.tabular_goggle import TabularGoggle
 
     module_disabled = False
-except ImportError:
+except ImportError as e:
     module_disabled = True
+    log.critical(f"Error importing TabularGoggle: {e}")
 
 
 class GOGGLEPlugin(Plugin):
@@ -89,7 +91,7 @@ class GOGGLEPlugin(Plugin):
         workspace: Path = Path("workspace"),
         compress_dataset: bool = False,
         dataloader_sampler: Optional[sampler.Sampler] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """
         .. inheritance-diagram:: synthcity.plugins.generic.plugin_goggle.GOGGLEPlugin


### PR DESCRIPTION
## Description
Add logging on failed tabular goggle import. 
Before the `goggle` plugin would be disabled if in import failed in one of goggles dependencies, but it would not specify which import had failed. This PR simply adds a logging statement to help debug the disabling of goggle, if it is wanted.

## Affected Dependencies
None

## How has this been tested?
- Automated tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
