### PR TITLE
update decaf pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     lifelines>=0.29.0, <0.30.0 # max due to xgbse
     opacus>=1.3, <1.5.4 # 1.5.4 introduces RMSNorm error
     networkx>2.0,<3.0
-    decaf-synthetic-data>=0.1.6
+    decaf-synthetic-data>=0.1.7
     optuna>=3.1
     shap
     tenacity


### PR DESCRIPTION

## Description
Update version pin on decaf to decaf-synthetic-data>=0.1.7. This version of decaf in tern has the version pin pytorch-lightning>=2.4. This solves this [security issue](https://github.com/advisories/GHSA-4cv3-v7pv-rfhf) and closes #332 .

## Affected Dependencies
decaf-synthetic-data>=0.1.7 from decaf-synthetic-data>=0.1.6

## How has this been tested?
- standard tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests