### PR TITLE
Bug: Fix PrivBayes data encoding bug

### DIFF
--- a/src/synthcity/plugins/privacy/plugin_privbayes.py
+++ b/src/synthcity/plugins/privacy/plugin_privbayes.py
@@ -153,15 +153,26 @@ class PrivBayes(Serializable):
         encoders = {}
 
         for col in data.columns:
-            if len(data[col].unique()) < self.n_bins or data[col].dtype.name not in [
-                "object",
-                "category",
-            ]:
+            dtype = data[col].dtype.name
+            n_unique = data[col].nunique()
+            
+            # Case 1 : categorical variables (string or category)
+            if dtype in ["object", "category"]:
                 encoders[col] = {
                     "type": "categorical",
                     "model": LabelEncoder().fit(data[col]),
                 }
                 data[col] = encoders[col]["model"].transform(data[col])
+
+            # Case 2 : discrete numerical variables with few distinct values
+            elif np.issubdtype(data[col].dtype, np.integer) and n_unique <= self.n_bins:
+                encoders[col] = {
+                    "type": "categorical",
+                    "model": LabelEncoder().fit(data[col]),
+                }
+                data[col] = encoders[col]["model"].transform(data[col])
+
+            # Case 3 : continuous variables (float or many unique values)
             else:
                 col_data = pd.cut(data[col], bins=self.n_bins)
                 encoders[col] = {


### PR DESCRIPTION
## Description
Fix an out-of-memory bug when fitting PrivBayes plugin on dataset with continuous columns.
Fixes #350.

You can consider that there is code duplication between case 1 and 2 (cf. the diff), but it was written this way for more clarity when reading the code (especially the conditions), in my opinion. I am open to merge these two conditions into one, if you prefer.

## Affected Dependencies
No additional dependency.

## How has this been tested?
- Run a training of PrivBayes model on dataset with continuous columns, which triggered the bug before the fix and is ok now.
- Existing privbayes tests have passed (`tests/plugins/privacy/test_privbayes.py`)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
