### PR TITLE
Update numpy version constraint in setup configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     torch>=2.1, <2.3 # Max due to tsai, min due to opacus
     scikit-learn>=1.2
     nflows>=0.14
-    numpy>=1.20, <2.0
+    numpy>=1.20
     lifelines>=0.29.0, <0.30.0 # max due to xgbse
     opacus>=1.3, <1.5.4 # 1.5.4 introduces RMSNorm error
     networkx>2.0,<3.0


### PR DESCRIPTION
synthcity 0.2.12 requires numpy >= 1.20, < 2.0
langchain-community requires numpy >= 2.1 on Python 3.13+

Facing issue with adding a compatible package version.